### PR TITLE
feat: add ohlc and trades polling with chart

### DIFF
--- a/netlify/functions/ohlc.ts
+++ b/netlify/functions/ohlc.ts
@@ -1,0 +1,67 @@
+import type { Handler } from '@netlify/functions';
+import type { OHLCResponse, ApiError, Provider, Timeframe } from '../../src/lib/types';
+import fs from 'fs/promises';
+
+const GT_FIXTURE = '../../fixtures/ohlc-gt-1m.json';
+const DS_FIXTURE = '../../fixtures/ohlc-ds-1m.json';
+
+function isValidPair(id?: string): id is string {
+  return !!id;
+}
+
+function isValidTf(tf?: string): tf is Timeframe {
+  return !!tf;
+}
+
+async function readFixture(path: string): Promise<OHLCResponse> {
+  const data = await fs.readFile(path, 'utf8');
+  return JSON.parse(data) as OHLCResponse;
+}
+
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return await Promise.race([
+    p,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error('timeout')), ms)),
+  ]);
+}
+
+export const handler: Handler = async (event) => {
+  const pairId = event.queryStringParameters?.pairId;
+  const tf = event.queryStringParameters?.tf as Timeframe | undefined;
+  const forceProvider = event.queryStringParameters?.provider as Provider | undefined;
+
+  if (!isValidPair(pairId) || !isValidTf(tf)) {
+    const body: ApiError = { error: 'invalid_request', provider: 'none' };
+    return { statusCode: 400, body: JSON.stringify(body) };
+  }
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=30, stale-while-revalidate=60',
+  };
+
+  try {
+    if (forceProvider !== 'ds') {
+      const gt = await withTimeout(readFixture(GT_FIXTURE), 3000);
+      gt.pairId = pairId;
+      if (tf !== '1m') {
+        gt.rollupHint = 'client';
+      }
+      return { statusCode: 200, headers, body: JSON.stringify(gt) };
+    }
+    throw new Error('forced ds');
+  } catch {
+    try {
+      const ds = await withTimeout(readFixture(DS_FIXTURE), 3000);
+      ds.pairId = pairId;
+      if (tf !== '1m') {
+        ds.rollupHint = 'client';
+      }
+      return { statusCode: 200, headers, body: JSON.stringify(ds) };
+    } catch {
+      const body: ApiError = { error: 'upstream_error', provider: 'none' };
+      return { statusCode: 500, headers, body: JSON.stringify(body) };
+    }
+  }
+};
+

--- a/netlify/functions/trades.ts
+++ b/netlify/functions/trades.ts
@@ -1,0 +1,56 @@
+import type { Handler } from '@netlify/functions';
+import type { TradesResponse, ApiError, Provider } from '../../src/lib/types';
+import fs from 'fs/promises';
+
+const GT_FIXTURE = '../../fixtures/trades-gt.json';
+const DS_FIXTURE = '../../fixtures/trades-ds.json';
+
+function isValidPair(id?: string): id is string {
+  return !!id;
+}
+
+async function readFixture(path: string): Promise<TradesResponse> {
+  const data = await fs.readFile(path, 'utf8');
+  return JSON.parse(data) as TradesResponse;
+}
+
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return await Promise.race([
+    p,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error('timeout')), ms)),
+  ]);
+}
+
+export const handler: Handler = async (event) => {
+  const pairId = event.queryStringParameters?.pairId;
+  const forceProvider = event.queryStringParameters?.provider as Provider | undefined;
+
+  if (!isValidPair(pairId)) {
+    const body: ApiError = { error: 'invalid_request', provider: 'none' };
+    return { statusCode: 400, body: JSON.stringify(body) };
+  }
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=30, stale-while-revalidate=60',
+  };
+
+  try {
+    if (forceProvider !== 'ds') {
+      const gt = await withTimeout(readFixture(GT_FIXTURE), 3000);
+      gt.pairId = pairId;
+      return { statusCode: 200, headers, body: JSON.stringify(gt) };
+    }
+    throw new Error('forced ds');
+  } catch {
+    try {
+      const ds = await withTimeout(readFixture(DS_FIXTURE), 3000);
+      ds.pairId = pairId;
+      return { statusCode: 200, headers, body: JSON.stringify(ds) };
+    } catch {
+      const body: ApiError = { error: 'upstream_error', provider: 'none' };
+      return { statusCode: 500, headers, body: JSON.stringify(body) };
+    }
+  }
+};
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "minidex",
       "version": "0.1.0",
       "dependencies": {
+        "lightweight-charts": "^4.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.0"
@@ -1285,6 +1286,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1340,6 +1347,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.2.3.tgz",
+      "integrity": "sha512-5kS/2hY3wNYNzhnS8Gb+GAS07DX8GPF2YVDnd2NMC85gJVQ6RLU6YrXNgNJ6eg0AnWPwCnvaGtYmGky3HiLQEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/loose-envify": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lightweight-charts": "^4.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0"

--- a/src/features/chart/ChartPage.tsx
+++ b/src/features/chart/ChartPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import type { PoolSummary, TokenMeta } from '../../lib/types';
 import { pairs } from '../../lib/api';
 import PoolSwitcher from './PoolSwitcher';
+import PriceChart from './PriceChart';
 
 // Views for chart page
 const views = ['chart', 'depth', 'trades', 'detail'] as const;
@@ -28,12 +29,13 @@ export default function ChartPage() {
         setCurrentPair(data.pools[0].pairId);
       }
     });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [chain, address]);
 
   function handlePoolSwitch(id: string) {
     setCurrentPair(id);
-    // keep xDomain untouched to preserve view intent
     setXDomain((d) => d);
     if (chain && address) {
       navigate(`/t/${chain}/${address}/${id}`, { replace: true });
@@ -61,12 +63,9 @@ export default function ChartPage() {
       {view !== 'detail' && (
         <PoolSwitcher pools={pools} current={currentPair} onSwitch={handlePoolSwitch} />
       )}
-      <div style={{ marginTop: '1rem' }}>
-        Current pair: {currentPair || '-'} | View: {view}
-      </div>
-      {xDomain && (
-        <div style={{ marginTop: '0.5rem', fontSize: '0.75rem' }}>
-          xDomain: {xDomain[0]} - {xDomain[1]}
+      {view === 'chart' && currentPair && (
+        <div style={{ marginTop: '1rem' }}>
+          <PriceChart pairId={currentPair} tf="1m" xDomain={xDomain} onXDomainChange={setXDomain} />
         </div>
       )}
     </div>

--- a/src/features/chart/PriceChart.tsx
+++ b/src/features/chart/PriceChart.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from 'react';
+import { createChart, type IChartApi, type UTCTimestamp } from 'lightweight-charts';
+import type { Timeframe, Candle } from '../../lib/types';
+import { ohlc, trades } from '../../lib/api';
+import { createPoller } from '../../lib/polling';
+import { rollupCandles } from '../../lib/time';
+
+interface Props {
+  pairId: string;
+  tf: Timeframe;
+  xDomain: [number, number] | null;
+  onXDomainChange?: (d: [number, number]) => void;
+}
+
+export default function PriceChart({ pairId, tf, xDomain, onXDomainChange }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const candleSeriesRef = useRef<any>(null);
+  const volumeSeriesRef = useRef<any>(null);
+  const [provider, setProvider] = useState<string>('');
+  const [degraded, setDegraded] = useState(false);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const chart = createChart(containerRef.current, { height: 300 });
+    const candleSeries = chart.addCandlestickSeries();
+    const volumeSeries = chart.addHistogramSeries({
+      priceScaleId: '',
+      priceFormat: { type: 'volume' },
+    });
+    volumeSeries.priceScale().applyOptions({
+      scaleMargins: { top: 0.8, bottom: 0 },
+    });
+    chartRef.current = chart;
+    candleSeriesRef.current = candleSeries;
+    volumeSeriesRef.current = volumeSeries;
+
+    function handleResize() {
+      chart.applyOptions({ width: containerRef.current!.clientWidth });
+    }
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    if (onXDomainChange) {
+      chart.timeScale().subscribeVisibleTimeRangeChange((range) => {
+        if (range && range.from !== undefined && range.to !== undefined) {
+          onXDomainChange([range.from as number, range.to as number]);
+        }
+      });
+    }
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      chart.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (xDomain && chartRef.current) {
+      chartRef.current.timeScale().setVisibleRange({ from: xDomain[0] as any, to: xDomain[1] as any });
+    }
+  }, [xDomain]);
+
+  useEffect(() => {
+    if (!pairId) return;
+    let candles: Candle[] = [];
+
+    const poller = createPoller(async () => {
+      const data = await ohlc(pairId, tf);
+      candles = data.candles;
+      if (data.rollupHint === 'client' && data.tf !== tf) {
+        candles = rollupCandles(candles, data.tf, tf);
+      }
+      const c = candles.map((cd) => ({
+        time: cd.t as UTCTimestamp,
+        open: cd.o,
+        high: cd.h,
+        low: cd.l,
+        close: cd.c,
+      }));
+      const v = candles.map((cd) => ({
+        time: cd.t as UTCTimestamp,
+        value: cd.v || 0,
+        color: cd.c >= cd.o ? '#26a69a' : '#ef5350',
+      }));
+      candleSeriesRef.current?.setData(c);
+      volumeSeriesRef.current?.setData(v);
+      setProvider(data.provider);
+    }, 5000, {
+      onError: () => setDegraded(true),
+      onRecover: () => setDegraded(false),
+    });
+    poller.start();
+
+    const tradesPoller = createPoller(async () => {
+      await trades(pairId);
+    }, 3000, {
+      onError: () => setDegraded(true),
+      onRecover: () => setDegraded(false),
+    });
+    tradesPoller.start();
+
+    return () => {
+      poller.stop();
+      tradesPoller.stop();
+    };
+  }, [pairId, tf]);
+
+  return (
+    <div style={{ position: 'relative' }}>
+      {degraded && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            background: 'rgba(255,0,0,0.2)',
+            color: '#900',
+            padding: '2px 4px',
+            fontSize: '12px',
+            textAlign: 'center',
+            zIndex: 1,
+          }}
+        >
+          degraded
+        </div>
+      )}
+      <div ref={containerRef} style={{ height: 300 }} />
+      {provider && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 4,
+            right: 4,
+            background: '#000',
+            color: '#fff',
+            padding: '2px 4px',
+            fontSize: '10px',
+            opacity: 0.7,
+          }}
+        >
+          {provider}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,36 +1,97 @@
-import type { CacheSearchEntry, SearchResponse, CachePairsEntry, PairsResponse } from './types';
+import type {
+  CacheSearchEntry,
+  SearchResponse,
+  CachePairsEntry,
+  PairsResponse,
+  CacheOHLCEntry,
+  OHLCResponse,
+  CacheTradesEntry,
+  TradesResponse,
+} from './types';
 
 const searchCache = new Map<string, CacheSearchEntry>();
 const pairsCache = new Map<string, CachePairsEntry>();
+const ohlcCache = new Map<string, CacheOHLCEntry>();
+const tradesCache = new Map<string, CacheTradesEntry>();
+
 const TTL_SECONDS = 30;
+const MAX_ENTRIES = 50;
 
+function now(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function getMapEntry<T>(map: Map<string, { response: T; ts: number }>, key: string): T | undefined {
+  let entry = map.get(key);
+  if (!entry && typeof sessionStorage !== 'undefined') {
+    const raw = sessionStorage.getItem(key);
+    if (raw) {
+      try {
+        entry = JSON.parse(raw) as { response: T; ts: number };
+        map.set(key, entry);
+      } catch {
+        sessionStorage.removeItem(key);
+      }
+    }
+  }
+  if (!entry) return undefined;
+  const age = now() - entry.ts;
+  if (age > TTL_SECONDS) {
+    map.delete(key);
+    if (typeof sessionStorage !== 'undefined') sessionStorage.removeItem(key);
+    return undefined;
+  }
+  return entry.response;
+}
+
+function setMapEntry<T>(map: Map<string, { response: T; ts: number }>, key: string, response: T) {
+  const entry = { response, ts: now() };
+  map.set(key, entry);
+  if (typeof sessionStorage !== 'undefined') {
+    try {
+      sessionStorage.setItem(key, JSON.stringify(entry));
+    } catch {
+      /* ignore */
+    }
+  }
+  if (map.size > MAX_ENTRIES) {
+    const oldestKey = map.keys().next().value as string | undefined;
+    if (oldestKey) {
+      map.delete(oldestKey);
+      if (typeof sessionStorage !== 'undefined') sessionStorage.removeItem(oldestKey);
+    }
+  }
+}
+
+// Search
 export function getSearchCache(query: string): SearchResponse | undefined {
-  const entry = searchCache.get(query);
-  if (!entry) return undefined;
-  const age = Math.floor(Date.now() / 1000) - entry.ts;
-  if (age > TTL_SECONDS) {
-    searchCache.delete(query);
-    return undefined;
-  }
-  return entry.response;
+  return getMapEntry(searchCache, `search:${query}`);
 }
-
 export function setSearchCache(query: string, response: SearchResponse) {
-  searchCache.set(query, { response, ts: Math.floor(Date.now() / 1000) });
+  setMapEntry(searchCache, `search:${query}`, response);
 }
 
+// Pairs
 export function getPairsCache(key: string): PairsResponse | undefined {
-  const entry = pairsCache.get(key);
-  if (!entry) return undefined;
-  const age = Math.floor(Date.now() / 1000) - entry.ts;
-  if (age > TTL_SECONDS) {
-    pairsCache.delete(key);
-    return undefined;
-  }
-  return entry.response;
+  return getMapEntry(pairsCache, `pairs:${key}`);
+}
+export function setPairsCache(key: string, response: PairsResponse) {
+  setMapEntry(pairsCache, `pairs:${key}`, response);
 }
 
-export function setPairsCache(key: string, response: PairsResponse) {
-  pairsCache.set(key, { response, ts: Math.floor(Date.now() / 1000) });
+// OHLC
+export function getOHLCCache(key: string): OHLCResponse | undefined {
+  return getMapEntry(ohlcCache, `ohlc:${key}`);
+}
+export function setOHLCCache(key: string, response: OHLCResponse) {
+  setMapEntry(ohlcCache, `ohlc:${key}`, response);
+}
+
+// Trades
+export function getTradesCache(key: string): TradesResponse | undefined {
+  return getMapEntry(tradesCache, `trades:${key}`);
+}
+export function setTradesCache(key: string, response: TradesResponse) {
+  setMapEntry(tradesCache, `trades:${key}`, response);
 }
 

--- a/src/lib/polling.ts
+++ b/src/lib/polling.ts
@@ -1,0 +1,76 @@
+export interface PollOptions {
+  onError?: (err: unknown) => void;
+  onRecover?: () => void;
+}
+
+export function createPoller(
+  fn: () => Promise<void>,
+  intervalMs: number,
+  options: PollOptions = {}
+) {
+  let timer: number | null = null;
+  let stopped = true;
+  const backoffs = [10000, 20000, 40000];
+  let backoffIndex = 0;
+  let inBackoff = false;
+
+  async function run() {
+    try {
+      await fn();
+      if (inBackoff) {
+        inBackoff = false;
+        backoffIndex = 0;
+        options.onRecover?.();
+      }
+      schedule(intervalMs);
+    } catch (err: any) {
+      const status = err?.status as number | undefined;
+      if (status === 429 || (status && status >= 500)) {
+        inBackoff = true;
+        options.onError?.(err);
+        const delay = backoffs[Math.min(backoffIndex, backoffs.length - 1)];
+        if (backoffIndex < backoffs.length - 1) backoffIndex++;
+        schedule(delay);
+      } else {
+        schedule(intervalMs);
+      }
+    }
+  }
+
+  function schedule(ms: number) {
+    timer = window.setTimeout(() => {
+      timer = null;
+      if (!stopped && !document.hidden) run();
+    }, ms);
+  }
+
+  function start() {
+    if (!stopped) return;
+    stopped = false;
+    if (!document.hidden) run();
+    document.addEventListener('visibilitychange', handleVisibility);
+  }
+
+  function stop() {
+    stopped = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    document.removeEventListener('visibilitychange', handleVisibility);
+  }
+
+  function handleVisibility() {
+    if (document.hidden) {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    } else if (!stopped) {
+      run();
+    }
+  }
+
+  return { start, stop };
+}
+

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,45 @@
+import type { Timeframe, Candle } from './types';
+
+export function timeframeToSeconds(tf: Timeframe): number {
+  switch (tf) {
+    case '1m':
+      return 60;
+    case '5m':
+      return 300;
+    case '15m':
+      return 900;
+    case '1h':
+      return 3600;
+    case '4h':
+      return 14400;
+    case '1d':
+      return 86400;
+  }
+}
+
+export function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export function rollupCandles(candles: Candle[], fromTf: Timeframe, toTf: Timeframe): Candle[] {
+  const fromSec = timeframeToSeconds(fromTf);
+  const toSec = timeframeToSeconds(toTf);
+  if (toSec <= fromSec || toSec % fromSec !== 0) return candles;
+  const result: Candle[] = [];
+  let current: Candle | null = null;
+  for (const c of candles) {
+    const bucketStart = Math.floor(c.t / toSec) * toSec;
+    if (!current || current.t !== bucketStart) {
+      if (current) result.push(current);
+      current = { t: bucketStart, o: c.o, h: c.h, l: c.l, c: c.c, v: c.v };
+    } else {
+      current.h = Math.max(current.h, c.h);
+      current.l = Math.min(current.l, c.l);
+      current.c = c.c;
+      if (c.v !== undefined) current.v = (current.v || 0) + c.v;
+    }
+  }
+  if (current) result.push(current);
+  return result;
+}
+


### PR DESCRIPTION
## Summary
- add Netlify OHLC and trades endpoints backed by fixtures and rollup hints
- implement polling utilities, caching, and timeframe helpers
- render candlestick & volume chart with provider badge and degraded state

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b9ac77fc08323938f43db6f29d233