### PR TITLE
feat: add trade markers toggle

### DIFF
--- a/src/features/chart/ChartOnlyView.tsx
+++ b/src/features/chart/ChartOnlyView.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+import type { Timeframe } from '../../lib/types';
+import PriceChart from './PriceChart';
+import { getTradeMarkers, type TradeMarkerCluster } from '../trades/TradeMarkers';
+
+interface Props {
+  pairId: string;
+  chain: string;
+  tf: Timeframe;
+  xDomain: [number, number] | null;
+  onXDomainChange?: (d: [number, number]) => void;
+}
+
+export default function ChartOnlyView({ pairId, chain, tf, xDomain, onXDomainChange }: Props) {
+  const [showMarkers, setShowMarkers] = useState(false);
+  const [markers, setMarkers] = useState<TradeMarkerCluster[]>([]);
+
+  useEffect(() => {
+    if (showMarkers) {
+      setMarkers(getTradeMarkers(pairId));
+    }
+  }, [pairId, showMarkers]);
+
+  function handleToggle() {
+    setShowMarkers((v) => {
+      const next = !v;
+      if (next) {
+        setMarkers(getTradeMarkers(pairId));
+      } else {
+        setMarkers([]);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          <input type="checkbox" checked={showMarkers} onChange={handleToggle} /> trades
+        </label>
+      </div>
+      <PriceChart
+        pairId={pairId}
+        tf={tf}
+        xDomain={xDomain}
+        onXDomainChange={onXDomainChange}
+        markers={showMarkers ? markers : []}
+        chain={chain}
+      />
+    </div>
+  );
+}
+

--- a/src/features/chart/ChartPage.tsx
+++ b/src/features/chart/ChartPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import type { PoolSummary, TokenMeta } from '../../lib/types';
 import { pairs } from '../../lib/api';
 import PoolSwitcher from './PoolSwitcher';
-import PriceChart from './PriceChart';
+import ChartOnlyView from './ChartOnlyView';
 
 // Views for chart page
 const views = ['chart', 'depth', 'trades', 'detail'] as const;
@@ -63,9 +63,15 @@ export default function ChartPage() {
       {view !== 'detail' && (
         <PoolSwitcher pools={pools} current={currentPair} onSwitch={handlePoolSwitch} />
       )}
-      {view === 'chart' && currentPair && (
+      {view === 'chart' && currentPair && chain && (
         <div style={{ marginTop: '1rem' }}>
-          <PriceChart pairId={currentPair} tf="1m" xDomain={xDomain} onXDomainChange={setXDomain} />
+          <ChartOnlyView
+            pairId={currentPair}
+            chain={chain}
+            tf="1m"
+            xDomain={xDomain}
+            onXDomainChange={setXDomain}
+          />
         </div>
       )}
     </div>

--- a/src/features/trades/TradeMarkers.ts
+++ b/src/features/trades/TradeMarkers.ts
@@ -1,0 +1,54 @@
+import type { Trade, TradeSide, TradeMarker } from '../../lib/types';
+import { getTradesCache } from '../../lib/cache';
+
+export interface TradeMarkerCluster extends TradeMarker {
+  trades: Trade[];
+}
+
+const MAX_MARKERS = 200;
+
+function shortAddr(addr?: string): string | undefined {
+  if (!addr) return undefined;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export function computeTradeMarkers(trades: Trade[], limit = MAX_MARKERS): TradeMarkerCluster[] {
+  const groups = new Map<string, Trade[]>();
+  for (const t of trades) {
+    const minute = Math.floor(t.ts / 60) * 60;
+    const key = `${minute}-${t.side}`;
+    const arr = groups.get(key) || [];
+    arr.push(t);
+    groups.set(key, arr);
+  }
+  const markers: TradeMarkerCluster[] = [];
+  for (const [key, arr] of groups.entries()) {
+    const [tsStr, sideStr] = key.split('-');
+    const ts = Number(tsStr);
+    const side = sideStr as TradeSide;
+    const size = arr.reduce((sum, t) => sum + (t.amountBase || 0), 0);
+    const price = arr[arr.length - 1].price;
+    const marker: TradeMarkerCluster = {
+      ts,
+      side,
+      price,
+      size,
+      clusterSize: arr.length,
+      trades: arr,
+    };
+    if (arr.length === 1) {
+      marker.txHash = arr[0].txHash;
+      marker.walletShort = shortAddr(arr[0].wallet);
+    }
+    markers.push(marker);
+  }
+  markers.sort((a, b) => a.ts - b.ts);
+  return markers.slice(-limit);
+}
+
+export function getTradeMarkers(pairId: string, limit = MAX_MARKERS): TradeMarkerCluster[] {
+  const cached = getTradesCache(pairId);
+  if (!cached) return [];
+  return computeTradeMarkers(cached.trades, limit);
+}
+

--- a/src/lib/chains.json
+++ b/src/lib/chains.json
@@ -1,9 +1,9 @@
 [
-  { "slug": "ethereum", "name": "Ethereum", "shortName": "ETH" },
-  { "slug": "arbitrum", "name": "Arbitrum One", "shortName": "ARB" },
-  { "slug": "polygon", "name": "Polygon", "shortName": "POL" },
-  { "slug": "bsc", "name": "BNB Chain", "shortName": "BNB" },
-  { "slug": "base", "name": "Base", "shortName": "BASE" },
-  { "slug": "optimism", "name": "Optimism", "shortName": "OP" },
-  { "slug": "avalanche", "name": "Avalanche", "shortName": "AVAX" }
+  { "slug": "ethereum", "name": "Ethereum", "shortName": "ETH", "explorerTx": "https://etherscan.io/tx/{tx}" },
+  { "slug": "arbitrum", "name": "Arbitrum One", "shortName": "ARB", "explorerTx": "https://arbiscan.io/tx/{tx}" },
+  { "slug": "polygon", "name": "Polygon", "shortName": "POL", "explorerTx": "https://polygonscan.com/tx/{tx}" },
+  { "slug": "bsc", "name": "BNB Chain", "shortName": "BNB", "explorerTx": "https://bscscan.com/tx/{tx}" },
+  { "slug": "base", "name": "Base", "shortName": "BASE", "explorerTx": "https://basescan.org/tx/{tx}" },
+  { "slug": "optimism", "name": "Optimism", "shortName": "OP", "explorerTx": "https://optimistic.etherscan.io/tx/{tx}" },
+  { "slug": "avalanche", "name": "Avalanche", "shortName": "AVAX", "explorerTx": "https://snowtrace.io/tx/{tx}" }
 ]


### PR DESCRIPTION
## Summary
- cluster cached trades into chart markers
- render buy/sell markers with crosshair tooltips and explorer links
- add chart-only view with trade markers toggle

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b9d2ec5308323bc03a122a2423da1