### PR TITLE
feat: add lists endpoint and UI

### DIFF
--- a/netlify/functions/lists.ts
+++ b/netlify/functions/lists.ts
@@ -1,0 +1,65 @@
+import type { Handler } from '@netlify/functions';
+import type { ListsResponse, ApiError, ListType, Window } from '../../src/lib/types';
+import fs from 'fs/promises';
+
+const FIXTURES: Record<string, string> = {
+  'trending:ethereum:1h': '../../fixtures/lists-trending-eth-1h.json',
+  'discovery:ethereum:1d': '../../fixtures/lists-discovery-eth-1d.json',
+  'leaderboard:ethereum:1d': '../../fixtures/lists-leaderboard-eth-1d.json',
+};
+
+function isValidType(t?: string): t is ListType {
+  return t === 'trending' || t === 'discovery' || t === 'leaderboard';
+}
+function isValidWindow(w?: string): w is Window {
+  return w === '1h' || w === '1d' || w === '1w';
+}
+function isValidChain(c?: string): c is string {
+  return !!c;
+}
+
+async function readFixture(path: string): Promise<ListsResponse> {
+  const data = await fs.readFile(path, 'utf8');
+  return JSON.parse(data) as ListsResponse;
+}
+
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return await Promise.race([
+    p,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error('timeout')), ms)),
+  ]);
+}
+
+export const handler: Handler = async (event) => {
+  const chain = event.queryStringParameters?.chain;
+  const type = event.queryStringParameters?.type as ListType | undefined;
+  const window = event.queryStringParameters?.window as Window | undefined;
+  const limitParam = event.queryStringParameters?.limit;
+  const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+
+  if (!isValidChain(chain) || !isValidType(type) || !isValidWindow(window)) {
+    const body: ApiError = { error: 'invalid_request', provider: 'none' };
+    return { statusCode: 400, body: JSON.stringify(body) };
+  }
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=30, stale-while-revalidate=60',
+  };
+
+  const key = `${type}:${chain}:${window}`;
+  const path = FIXTURES[key];
+  if (!path) {
+    const body: ApiError = { error: 'not_found', provider: 'none' };
+    return { statusCode: 404, headers, body: JSON.stringify(body) };
+  }
+
+  try {
+    const data = await withTimeout(readFixture(path), 3000);
+    if (limit !== undefined) data.items = data.items.slice(0, limit);
+    return { statusCode: 200, headers, body: JSON.stringify(data) };
+  } catch {
+    const body: ApiError = { error: 'upstream_error', provider: 'none' };
+    return { statusCode: 500, headers, body: JSON.stringify(body) };
+  }
+};

--- a/src/components/VirtualList.tsx
+++ b/src/components/VirtualList.tsx
@@ -1,0 +1,46 @@
+import { useRef, useState, useEffect } from 'react';
+
+interface VirtualListProps<T> {
+  items: T[];
+  itemHeight: number; // fixed height per item in px
+  render: (item: T, index: number) => React.ReactNode;
+}
+
+export default function VirtualList<T>({ items, itemHeight, render }: VirtualListProps<T>) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const element = el; // non-null reference
+    function onScroll() {
+      setScrollTop(element.scrollTop);
+    }
+    function onResize() {
+      setHeight(element.clientHeight);
+    }
+    onResize();
+    element.addEventListener('scroll', onScroll);
+    window.addEventListener('resize', onResize);
+    return () => {
+      element.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onResize);
+    };
+  }, []);
+
+  const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight));
+  const endIndex = Math.min(items.length, Math.ceil((scrollTop + height) / itemHeight));
+  const paddingTop = startIndex * itemHeight;
+  const paddingBottom = (items.length - endIndex) * itemHeight;
+  const visible = items.slice(startIndex, endIndex);
+
+  return (
+    <div ref={containerRef} style={{ overflowY: 'auto', height: '100%' }}>
+      <div style={{ paddingTop, paddingBottom }}>
+        {visible.map((item, i) => render(item, startIndex + i))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/lists/ListItem.tsx
+++ b/src/features/lists/ListItem.tsx
@@ -1,0 +1,54 @@
+import { useNavigate } from 'react-router-dom';
+import type { ListItem as Item, Provider } from '../../lib/types';
+
+interface Props {
+  item: Item;
+  rank: number;
+  provider: Provider;
+}
+
+function pairFromId(pairId: string): string {
+  const parts = pairId.split('_');
+  if (parts.length >= 2) {
+    const base = parts[parts.length - 2];
+    const quote = parts[parts.length - 1];
+    return `${base.toUpperCase()}/${quote.toUpperCase()}`;
+    }
+  return pairId;
+}
+
+export default function ListItem({ item, rank, provider }: Props) {
+  const navigate = useNavigate();
+  const pair = pairFromId(item.pairId);
+  function handleClick() {
+    navigate(`/t/${item.chain}/${item.token.address}/${item.pairId}`);
+  }
+  return (
+    <div
+      onClick={handleClick}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '40px 1fr 80px 80px 80px 80px 80px 60px',
+        gap: '0.5rem',
+        padding: '0.5rem',
+        cursor: 'pointer',
+        borderBottom: '1px solid #eee',
+        background: item.promoted ? '#fffbe6' : undefined,
+      }}
+    >
+      <div>{rank}</div>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <strong>{item.token.symbol}</strong>
+        <span style={{ fontSize: '0.75rem', color: '#666' }}>{pair}</span>
+      </div>
+      <div>{item.priceUsd !== undefined ? `$${item.priceUsd.toFixed(4)}` : '-'}</div>
+      <div>{item.liqUsd !== undefined ? `$${item.liqUsd.toLocaleString()}` : '-'}</div>
+      <div>{item.volWindowUsd !== undefined ? `$${item.volWindowUsd.toLocaleString()}` : '-'}</div>
+      <div>{item.priceChangePct !== undefined ? `${item.priceChangePct.toFixed(2)}%` : '-'}</div>
+      <div>{item.score !== undefined ? item.score.toFixed(2) : '-'}</div>
+      <div style={{ justifySelf: 'end' }}>
+        <span style={{ fontSize: '0.75rem', border: '1px solid #999', padding: '0 0.25rem' }}>{provider}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/features/lists/ListsPage.tsx
+++ b/src/features/lists/ListsPage.tsx
@@ -1,0 +1,124 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import type { ListItem as Item, Window, ListsResponse, Provider } from '../../lib/types';
+import ListItem from './ListItem';
+import VirtualList from '../../components/VirtualList';
+import { createPoller } from '../../lib/polling';
+
+const windows: Window[] = ['1h', '1d', '1w'];
+
+export default function ListsPage() {
+  const { chain, type } = useParams<{ chain: string; type: string }>();
+  const [windowSel, setWindowSel] = useState<Window>('1h');
+  const [items, setItems] = useState<Item[]>([]);
+  const [provider, setProvider] = useState<Provider | undefined>();
+  const [sortKey, setSortKey] = useState<keyof Item | 'rank'>('rank');
+  const [sortAsc, setSortAsc] = useState(false);
+
+  const fetchLists = useCallback(async () => {
+    if (!chain || !type) return;
+    const url = new URL('/.netlify/functions/lists', window.location.origin);
+    url.searchParams.set('chain', chain);
+    url.searchParams.set('type', type);
+    url.searchParams.set('window', windowSel);
+    const res = await fetch(url.toString());
+    if (!res.ok) {
+      setItems([]);
+      return;
+    }
+    const data = (await res.json()) as ListsResponse;
+    setItems(data.items);
+    setProvider(data.provider);
+  }, [chain, type, windowSel]);
+
+  useEffect(() => {
+    fetchLists();
+    const poller = createPoller(fetchLists, 60000);
+    poller.start();
+    return () => poller.stop();
+  }, [fetchLists]);
+
+  function handleSort(key: keyof Item | 'rank') {
+    if (sortKey === key) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortKey(key);
+      setSortAsc(false);
+    }
+  }
+
+  const sorted = useMemo(() => {
+    const indexed = items.map((it, idx) => ({ it, idx }));
+    indexed.sort((a, b) => {
+      if (sortKey === 'rank') return a.idx - b.idx; // original order
+      const av = (a.it as any)[sortKey];
+      const bv = (b.it as any)[sortKey];
+      if (av === undefined && bv === undefined) return a.idx - b.idx;
+      if (av === undefined) return 1;
+      if (bv === undefined) return -1;
+      if (av < bv) return -1;
+      if (av > bv) return 1;
+      return a.idx - b.idx;
+    });
+    if (!sortAsc) indexed.reverse();
+    return indexed.map((x) => x.it);
+  }, [items, sortKey, sortAsc]);
+
+  return (
+    <div style={{ padding: '1rem', height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ marginBottom: '0.5rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <strong style={{ textTransform: 'capitalize' }}>{type}</strong>
+        <select value={windowSel} onChange={(e) => setWindowSel(e.target.value as Window)}>
+          {windows.map((w) => (
+            <option key={w} value={w}>{w}</option>
+          ))}
+        </select>
+      </div>
+      <div style={{ flex: 1, border: '1px solid #ccc', display: 'flex', flexDirection: 'column' }}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '40px 1fr 80px 80px 80px 80px 80px 60px',
+            gap: '0.5rem',
+            padding: '0.5rem',
+            fontWeight: 'bold',
+            position: 'sticky',
+            top: 0,
+            background: '#fff',
+            zIndex: 1,
+          }}
+        >
+          <div style={{ cursor: 'pointer' }} onClick={() => handleSort('rank')}>
+            # {sortKey === 'rank' ? (sortAsc ? '▲' : '▼') : ''}
+          </div>
+          <div>Token</div>
+          <div style={{ cursor: 'pointer' }} onClick={() => handleSort('priceUsd')}>
+            Price {sortKey === 'priceUsd' ? (sortAsc ? '▲' : '▼') : ''}
+          </div>
+          <div style={{ cursor: 'pointer' }} onClick={() => handleSort('liqUsd')}>
+            Liq {sortKey === 'liqUsd' ? (sortAsc ? '▲' : '▼') : ''}
+          </div>
+          <div style={{ cursor: 'pointer' }} onClick={() => handleSort('volWindowUsd')}>
+            Vol {sortKey === 'volWindowUsd' ? (sortAsc ? '▲' : '▼') : ''}
+          </div>
+          <div style={{ cursor: 'pointer' }} onClick={() => handleSort('priceChangePct')}>
+            % {sortKey === 'priceChangePct' ? (sortAsc ? '▲' : '▼') : ''}
+          </div>
+          <div style={{ cursor: 'pointer' }} onClick={() => handleSort('score')}>
+            Score {sortKey === 'score' ? (sortAsc ? '▲' : '▼') : ''}
+          </div>
+          <div></div>
+        </div>
+        <div style={{ flex: 1 }}>
+          <VirtualList
+            items={sorted}
+            itemHeight={56}
+            render={(item, idx) => (
+              <ListItem key={item.pairId} item={item} rank={idx + 1} provider={provider || 'gt'} />
+            )}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Lists.tsx
+++ b/src/pages/Lists.tsx
@@ -1,3 +1,5 @@
+import ListsPage from '../features/lists/ListsPage';
+
 export default function Lists() {
-  return <div style={{ padding: '1rem' }}>Lists Page</div>;
+  return <ListsPage />;
 }


### PR DESCRIPTION
## Summary
- add `/api/lists` serverless function serving fixtures with 60s cache
- create virtualized list component and list item with promoted styling
- build lists page with window switching, sorting, polling

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689ba00580f0832396d3754193cb3549