### PR TITLE
feat: add optional metrics panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "lightweight-charts": "^4.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.22.0"
+        "react-router-dom": "^6.22.0",
+        "uplot": "^1.6.17"
       },
       "devDependencies": {
         "@types/react": "^18.2.14",
@@ -1629,6 +1630,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/uplot": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.17.tgz",
+      "integrity": "sha512-WHNHvDCXURn+Qwb3QUUzP6rOxx+3kUZUspREyhkqmXCxFIND99l5z9intTh+uPEt+/EEu7lCaMjSd1uTfuTXfg==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.19",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lightweight-charts": "^4.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.0"
+    "react-router-dom": "^6.22.0",
+    "uplot": "^1.6.17"
   },
   "devDependencies": {
     "@types/react": "^18.2.14",

--- a/src/features/metrics/MetricsPanel.tsx
+++ b/src/features/metrics/MetricsPanel.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect, useRef } from 'react';
+import type { MetricKey, MetricSeries, Timeframe } from '../../lib/types';
+import {
+  getOHLCCache,
+  getTradesCache,
+} from '../../lib/cache';
+import {
+  rollingVolumeBase,
+  liquidityUsd,
+  atrLite,
+  returnsZScore,
+  tradesPerInterval,
+  ric,
+} from '../../lib/transforms';
+
+interface Props {
+  pairId: string;
+  tf: Timeframe;
+}
+
+const METRICS: { key: MetricKey; label: string }[] = [
+  { key: 'rollingVolumeBase', label: 'Rolling Volume' },
+  { key: 'liquidityUsd', label: 'Liquidity' },
+  { key: 'atrLite', label: 'ATR-lite' },
+  { key: 'returnsZScore', label: 'Returns Z-Score' },
+  { key: 'tradesPerInterval', label: 'Trades/Interval' },
+];
+
+function MetricChart({ series }: { series: MetricSeries }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    let plot: any;
+    let mounted = true;
+    import('uplot').then((uPlot) => {
+      if (!mounted) return;
+      const data: any = [
+        series.points.map((p) => p.t),
+        series.points.map((p) => p.v),
+      ];
+      plot = new uPlot.default(
+        {
+          width: 200,
+          height: 60,
+          series: [{}, { stroke: 'cyan' }],
+          axes: [{}, {}],
+        },
+        data,
+        ref.current!
+      );
+    });
+    return () => {
+      mounted = false;
+      if (plot) plot.destroy();
+    };
+  }, [series]);
+  return <div ref={ref} />;
+}
+
+export default function MetricsPanel({ pairId, tf }: Props) {
+  const [enabled, setEnabled] = useState<MetricKey[]>([]);
+  const [seriesMap, setSeriesMap] = useState<
+    Partial<Record<MetricKey, MetricSeries>
+  >>({});
+
+  const candles = getOHLCCache(`${pairId}:${tf}`)?.candles || [];
+  const trades = getTradesCache(pairId)?.trades || [];
+
+  function toggle(key: MetricKey) {
+    if (enabled.includes(key)) {
+      setEnabled(enabled.filter((k) => k !== key));
+      setSeriesMap((prev) => {
+        const { [key]: _omit, ...rest } = prev;
+        return rest;
+      });
+      return;
+    }
+    setEnabled([...enabled, key]);
+    ric(() => {
+      let s: MetricSeries | undefined;
+      switch (key) {
+        case 'rollingVolumeBase':
+          s = rollingVolumeBase(candles);
+          break;
+        case 'liquidityUsd':
+          s = liquidityUsd(trades, tf);
+          break;
+        case 'atrLite':
+          s = atrLite(candles);
+          break;
+        case 'returnsZScore':
+          s = returnsZScore(candles);
+          break;
+        case 'tradesPerInterval':
+          s = tradesPerInterval(trades, tf);
+          break;
+      }
+      if (s) setSeriesMap((prev) => ({ ...prev, [key]: s! }));
+    });
+  }
+
+  return (
+    <div>
+      {METRICS.map((m) => (
+        <div key={m.key} style={{ marginBottom: 8 }}>
+          <label>
+            <input
+              type="checkbox"
+              checked={enabled.includes(m.key)}
+              onChange={() => toggle(m.key)}
+            />{' '}
+            {m.label}
+          </label>
+          {enabled.includes(m.key) && seriesMap[m.key] && (
+            <MetricChart series={seriesMap[m.key]!} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/transforms.ts
+++ b/src/lib/transforms.ts
@@ -1,0 +1,118 @@
+import type { Candle, Trade, Timeframe, MetricSeries } from './types';
+import { timeframeToSeconds } from './time';
+
+const ric =
+  typeof requestIdleCallback !== 'undefined'
+    ? requestIdleCallback
+    : (cb: () => void) => setTimeout(cb, 0);
+
+/* --- Rolling volume (base token) --- */
+export function rollingVolumeBase(
+  candles: Candle[],
+  window = 14
+): MetricSeries {
+  const points: MetricSeries['points'] = [];
+  let sum = 0;
+  for (let i = 0; i < candles.length; i++) {
+    const v = candles[i].v || 0;
+    sum += v;
+    if (i >= window) sum -= candles[i - window].v || 0;
+    if (i >= window - 1) {
+      points.push({ t: candles[i].t, v: sum });
+    }
+  }
+  return { key: 'rollingVolumeBase', points };
+}
+
+/* --- Liquidity (USD, approximated by trade sizes) --- */
+export function liquidityUsd(
+  trades: Trade[],
+  tf: Timeframe,
+  window = 14
+): MetricSeries {
+  const bucketSec = timeframeToSeconds(tf);
+  const buckets = new Map<number, number>();
+  trades.forEach((tr) => {
+    const bucket = Math.floor(tr.ts / bucketSec) * bucketSec;
+    const val =
+      tr.amountQuote ??
+      (tr.amountBase !== undefined ? tr.amountBase * (tr.price || 0) : 0);
+    buckets.set(bucket, (buckets.get(bucket) || 0) + val);
+  });
+  const entries = Array.from(buckets.entries()).sort((a, b) => a[0] - b[0]);
+  const roll: { t: number; v: number }[] = entries.map(([t, v]) => ({ t, v }));
+  const points: MetricSeries['points'] = [];
+  let sum = 0;
+  for (let i = 0; i < roll.length; i++) {
+    sum += roll[i].v;
+    if (i >= window) sum -= roll[i - window].v;
+    if (i >= window - 1) points.push({ t: roll[i].t, v: sum / window });
+  }
+  return { key: 'liquidityUsd', points, unit: 'USD' };
+}
+
+/* --- ATR-lite --- */
+export function atrLite(candles: Candle[], window = 14): MetricSeries {
+  const tr: number[] = [];
+  for (let i = 0; i < candles.length; i++) {
+    const c = candles[i];
+    const prevClose = i > 0 ? candles[i - 1].c : c.o;
+    const range = Math.max(
+      c.h - c.l,
+      Math.abs(c.h - prevClose),
+      Math.abs(c.l - prevClose)
+    );
+    tr.push(range);
+  }
+  const points: MetricSeries['points'] = [];
+  let sum = 0;
+  for (let i = 0; i < tr.length; i++) {
+    sum += tr[i];
+    if (i >= window) sum -= tr[i - window];
+    if (i >= window - 1) points.push({ t: candles[i].t, v: sum / window });
+  }
+  return { key: 'atrLite', points };
+}
+
+/* --- Returns z-score --- */
+export function returnsZScore(
+  candles: Candle[],
+  window = 20
+): MetricSeries {
+  const returns: number[] = [];
+  for (let i = 1; i < candles.length; i++) {
+    const prev = candles[i - 1].c;
+    const ret = prev ? Math.log(candles[i].c / prev) : 0;
+    returns.push(ret);
+  }
+  const points: MetricSeries['points'] = [];
+  for (let i = window - 1; i < returns.length; i++) {
+    const slice = returns.slice(i - window + 1, i + 1);
+    const mean = slice.reduce((a, b) => a + b, 0) / window;
+    const std = Math.sqrt(
+      slice.reduce((a, b) => a + (b - mean) ** 2, 0) / window
+    );
+    const z = std ? (returns[i] - mean) / std : 0;
+    points.push({ t: candles[i + 1].t, v: z });
+  }
+  return { key: 'returnsZScore', points };
+}
+
+/* --- Trades per interval --- */
+export function tradesPerInterval(
+  trades: Trade[],
+  tf: Timeframe
+): MetricSeries {
+  const bucketSec = timeframeToSeconds(tf);
+  const buckets = new Map<number, number>();
+  trades.forEach((tr) => {
+    const bucket = Math.floor(tr.ts / bucketSec) * bucketSec;
+    buckets.set(bucket, (buckets.get(bucket) || 0) + 1);
+  });
+  const points = Array.from(buckets.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([t, v]) => ({ t, v }));
+  return { key: 'tradesPerInterval', points };
+}
+
+export { ric };


### PR DESCRIPTION
## Summary
- compute rolling volume, liquidity, ATR-lite, return z-score, and trades/interval metrics
- add toggleable MetricsPanel rendering uPlot sparklines on demand

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ba1a484d8832380aeaa59eb39149f