### PR TITLE
feat: improve accessibility and error states

### DIFF
--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 const tabs = [
   { view: 'detail', label: 'Detail' },
@@ -10,17 +10,26 @@ const tabs = [
 export default function BottomTabs() {
   const location = useLocation();
   const { pathname, search } = location;
-  const qs = new URLSearchParams(search);
+  const currentView = new URLSearchParams(search).get('view') || 'detail';
 
   return (
-    <nav className="bottom-tabs">
+    <nav className="bottom-tabs" role="tablist" aria-label="Views">
       {tabs.map((tab) => {
+        const qs = new URLSearchParams(search);
         qs.set('view', tab.view);
         const to = `${pathname}?${qs.toString()}`;
+        const isActive = currentView === tab.view;
         return (
-          <NavLink key={tab.view} to={to} className={({ isActive }) => (isActive ? 'active' : '')}>
+          <Link
+            key={tab.view}
+            to={to}
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            className={isActive ? 'active' : ''}
+          >
             {tab.label}
-          </NavLink>
+          </Link>
         );
       })}
     </nav>

--- a/src/copy/en.json
+++ b/src/copy/en.json
@@ -1,6 +1,9 @@
 {
   "search_placeholder": "Token address",
   "no_results": "No results found",
+  "no_pools": "No pools available",
+  "loading": "Loading...",
   "error_generic": "Something went wrong",
-  "error_invalid_address": "Invalid address"
+  "error_invalid_address": "Invalid address",
+  "error_rate_limit": "Too many requests, please slow down"
 }

--- a/src/features/search/SearchPage.tsx
+++ b/src/features/search/SearchPage.tsx
@@ -34,10 +34,14 @@ export default function SearchPage() {
           style={{ width: '100%', padding: '0.5rem' }}
         />
       </form>
-      {loading && <div>Loading...</div>}
+      {loading && <div>{copy.loading}</div>}
       {error && (
         <div style={{ color: 'red' }}>
-          {error === 'invalid_address' ? copy.error_invalid_address : copy.error_generic}
+          {error === 'invalid_address'
+            ? copy.error_invalid_address
+            : error === 'rate_limit'
+            ? copy.error_rate_limit
+            : copy.error_generic}
         </div>
       )}
       {!loading && results && results.length === 0 && <div>{copy.no_results}</div>}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -77,3 +77,25 @@ main.with-tabs {
 .bottom-tabs a.active {
   color: var(--color-accent);
 }
+
+.bottom-tabs a:focus-visible {
+  outline: 2px solid var(--color-accent);
+}
+
+.view-tabs {
+  margin-bottom: 1rem;
+}
+
+.view-tab {
+  margin-right: 0.5rem;
+  min-height: 44px;
+  padding: 0 0.5rem;
+}
+
+.view-tab[aria-selected='true'] {
+  font-weight: bold;
+}
+
+.view-tab:focus-visible {
+  outline: 2px solid var(--color-accent);
+}


### PR DESCRIPTION
## Summary
- add missing copy for loading, no pools and rate limit errors
- expose tab roles and focus outlines for view and bottom tab switchers
- surface loading, empty and rate-limit states on chart and search pages

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ba29b891c83239b738228cab5c0c0