### PR TITLE
feat: wire header search pill and menu

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,82 @@
-import { Link } from 'react-router-dom';
+import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function Header() {
+  const navigate = useNavigate();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const first = menuRef.current?.querySelector<HTMLElement>('a, button');
+    first?.focus();
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setMenuOpen(false);
+      } else if (e.key === 'Tab' && menuRef.current) {
+        const focusables = menuRef.current.querySelectorAll<HTMLElement>('a, button');
+        if (focusables.length === 0) return;
+        const firstEl = focusables[0];
+        const lastEl = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === firstEl) {
+          e.preventDefault();
+          lastEl.focus();
+        } else if (!e.shiftKey && document.activeElement === lastEl) {
+          e.preventDefault();
+          firstEl.focus();
+        }
+      }
+    }
+
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+
+    document.addEventListener('keydown', handleKey);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [menuOpen]);
+
+  function handleSearchClick() {
+    navigate('/');
+    setTimeout(() => {
+      const input = document.getElementById('search-input') as HTMLInputElement | null;
+      input?.focus();
+    }, 0);
+  }
+
   return (
     <header className="header">
-      <button className="menu-btn" aria-label="Menu">☰</button>
-      <Link to="/" className="search-pill">Search</Link>
+      <button
+        type="button"
+        className="menu-btn"
+        aria-label="Menu"
+        aria-expanded={menuOpen}
+        aria-controls="main-menu"
+        onClick={() => setMenuOpen((o) => !o)}
+      >
+        ☰
+      </button>
+      <button type="button" className="search-pill" onClick={handleSearchClick} aria-label="Search">
+        Search
+      </button>
+      {menuOpen && (
+        <nav id="main-menu" ref={menuRef} className="menu-sheet" aria-label="Main menu">
+          <ul>
+            <li>
+              <button type="button" onClick={() => setMenuOpen(false)}>
+                Close
+              </button>
+            </li>
+          </ul>
+        </nav>
+      )}
     </header>
   );
 }

--- a/src/features/search/SearchPage.tsx
+++ b/src/features/search/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import type { SearchResult } from '../../lib/types';
 import { search } from '../../lib/api';
 import copy from '../../copy/en.json';
@@ -9,6 +9,11 @@ export default function SearchPage() {
   const [results, setResults] = useState<SearchResult[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   async function handleSearch(e: React.FormEvent) {
     e.preventDefault();
@@ -28,6 +33,8 @@ export default function SearchPage() {
     <div style={{ padding: '1rem' }}>
       <form onSubmit={handleSearch} style={{ marginBottom: '1rem' }}>
         <input
+          id="search-input"
+          ref={inputRef}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={copy.search_placeholder}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,6 +36,7 @@ a {
   border: none;
   color: var(--color-text);
   font-size: 1.25rem;
+  cursor: pointer;
 }
 
 .search-pill {
@@ -45,6 +46,30 @@ a {
   padding: 0.4rem 0.8rem;
   border-radius: var(--radius);
   color: var(--color-text-muted);
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.menu-btn:focus-visible,
+.search-pill:focus-visible {
+  outline: 2px solid var(--color-accent);
+}
+
+.menu-sheet {
+  position: absolute;
+  top: 48px;
+  right: 0;
+  background: var(--color-bg-muted);
+  border: 1px solid var(--color-surface);
+  padding: 0.5rem;
+  z-index: 20;
+}
+
+.menu-sheet ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 main {


### PR DESCRIPTION
## Summary
- make header search pill a button that navigates home and focuses the search input
- add accessible menu sheet with escape and outside-click to close
- style focus outlines and menu sheet layering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c62e0ed948323afa0d033606a9119