### PR TITLE
feat: polish search page UX

### DIFF
--- a/src/copy/en.json
+++ b/src/copy/en.json
@@ -5,5 +5,7 @@
   "loading": "Loading...",
   "error_generic": "Something went wrong",
   "error_invalid_address": "Invalid address",
-  "error_rate_limit": "Too many requests, please slow down"
+  "error_rate_limit": "Too many requests, please slow down",
+  "error_upstream": "Network error, please try again",
+  "retry": "Retry"
 }

--- a/src/features/search/SearchPage.tsx
+++ b/src/features/search/SearchPage.tsx
@@ -1,58 +1,143 @@
 import { useState, useRef, useEffect } from 'react';
-import type { SearchResult } from '../../lib/types';
+import type { SearchResult, Provider } from '../../lib/types';
 import { search } from '../../lib/api';
 import copy from '../../copy/en.json';
-import SearchResultItem from './SearchResultItem';
+import SearchResultItem, { SearchResultSkeleton } from './SearchResultItem';
 
 export default function SearchPage() {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [provider, setProvider] = useState<Provider | ''>('');
+  const [backoff, setBackoff] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
-  async function handleSearch(e: React.FormEvent) {
+  useEffect(() => {
+    if (backoff > 0) {
+      const t = setTimeout(() => setBackoff(backoff - 1), 1000);
+      return () => clearTimeout(t);
+    }
+  }, [backoff]);
+
+  function isValid(addr: string) {
+    return /^0x[a-fA-F0-9]{40}$/.test(addr.trim());
+  }
+
+  async function handleSearch(e: React.FormEvent | React.MouseEvent) {
     e.preventDefault();
+    if (!isValid(query)) {
+      setResults(null);
+      setProvider('');
+      setError('invalid_address');
+      return;
+    }
     setLoading(true);
     setError(null);
+    setProvider('');
     const data = await search(query);
     setLoading(false);
     if ('error' in data) {
       setResults(null);
       setError(data.error);
+      setProvider(data.provider !== 'none' ? data.provider : '');
+      if (data.error === 'rate_limit') setBackoff(5);
     } else {
       setResults(data.results);
+      setProvider(data.results[0]?.provider || '');
     }
   }
 
   return (
     <div style={{ padding: '1rem' }}>
-      <form onSubmit={handleSearch} style={{ marginBottom: '1rem' }}>
+      <form onSubmit={handleSearch} style={{ marginBottom: '0.5rem' }}>
+        <label htmlFor="search-input" style={{ position: 'absolute', left: '-10000px' }}>
+          {copy.search_placeholder}
+        </label>
         <input
           id="search-input"
           ref={inputRef}
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            if (error === 'invalid_address') setError(null);
+          }}
           placeholder={copy.search_placeholder}
+          aria-label={copy.search_placeholder}
           style={{ width: '100%', padding: '0.5rem' }}
         />
       </form>
-      {loading && <div>{copy.loading}</div>}
-      {error && (
-        <div style={{ color: 'red' }}>
-          {error === 'invalid_address'
-            ? copy.error_invalid_address
-            : error === 'rate_limit'
-            ? copy.error_rate_limit
-            : copy.error_generic}
+      {error === 'invalid_address' && (
+        <div style={{ color: 'red', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
+          {copy.error_invalid_address}
+        </div>
+      )}
+      {error && error !== 'invalid_address' && (
+        <div style={{
+          background: '#fee',
+          color: '#900',
+          padding: '0.5rem',
+          marginBottom: '0.5rem',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center'
+        }}>
+          <span>
+            {error === 'rate_limit'
+              ? `${copy.error_rate_limit}${backoff > 0 ? ` (${backoff})` : ''}`
+              : copy.error_upstream}
+          </span>
+          {error === 'upstream_error' && (
+            <button onClick={handleSearch}>{copy.retry}</button>
+          )}
+        </div>
+      )}
+      {provider && (
+        <div style={{ marginBottom: '0.5rem' }}>
+          <span
+            aria-label={`data provider ${provider}`}
+            style={{ fontSize: '0.75rem', border: '1px solid #999', padding: '0 0.25rem' }}
+          >
+            {provider}
+          </span>
+        </div>
+      )}
+      {(loading || (results && results.length > 0)) && (
+        <div style={{ border: '1px solid #ccc' }}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '40px 1fr 80px 80px 80px 80px 80px 60px',
+              gap: '0.5rem',
+              padding: '0.5rem',
+              fontWeight: 'bold',
+              position: 'sticky',
+              top: 0,
+              background: '#fff'
+            }}
+          >
+            <div></div>
+            <div>Token</div>
+            <div>Chain</div>
+            <div>Price</div>
+            <div>Liq</div>
+            <div>Vol24h</div>
+            <div>%</div>
+            <div>Pools</div>
+          </div>
+          {loading && Array.from({ length: 5 }).map((_, i) => <SearchResultSkeleton key={i} />)}
+          {!loading &&
+            results &&
+            results.map((r) => (
+              <SearchResultItem key={r.token.address + r.chain} result={r} />
+            ))}
         </div>
       )}
       {!loading && results && results.length === 0 && <div>{copy.no_results}</div>}
-      {!loading && results && results.map((r) => <SearchResultItem key={r.token.address + r.chain} result={r} />)}
     </div>
   );
 }

--- a/src/features/search/SearchResultItem.tsx
+++ b/src/features/search/SearchResultItem.tsx
@@ -1,37 +1,68 @@
+import { useNavigate } from 'react-router-dom';
 import type { SearchResult } from '../../lib/types';
 
 interface Props { result: SearchResult }
 
-export default function SearchResultItem({ result }: Props) {
-  const { token, core, pools, provider, chain } = result;
+export function SearchResultSkeleton() {
   return (
-    <div style={{ border: '1px solid #ccc', padding: '0.5rem', marginBottom: '0.5rem' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        {token.icon && (
-          <img src={token.icon} alt={token.symbol} style={{ width: 24, height: 24 }} />
-        )}
-        <div style={{ flex: 1 }}>
-          <div><strong>{token.symbol}</strong> {token.name}</div>
-          <div style={{ fontSize: '0.75rem', color: '#666' }}>{chain}</div>
-        </div>
-        <span style={{ fontSize: '0.75rem', border: '1px solid #999', padding: '0 0.25rem' }}>
-          {provider}
-        </span>
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '40px 1fr 80px 80px 80px 80px 80px 60px',
+        gap: '0.5rem',
+        padding: '0.5rem',
+        borderBottom: '1px solid #eee'
+      }}
+    >
+      <div style={{ width: 24, height: 24, background: '#eee', borderRadius: 4 }} />
+      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
+      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
+      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
+      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
+      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
+      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
+      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
+    </div>
+  );
+}
+
+export default function SearchResultItem({ result }: Props) {
+  const navigate = useNavigate();
+  const { token, core, pools, chain } = result;
+  function handleClick() {
+    const pairId = pools[0]?.pairId;
+    navigate(`/t/${chain}/${token.address}/${pairId || ''}`);
+  }
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={(e) => { if (e.key === 'Enter') handleClick(); }}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '40px 1fr 80px 80px 80px 80px 80px 60px',
+        gap: '0.5rem',
+        padding: '0.5rem',
+        cursor: 'pointer',
+        borderBottom: '1px solid #eee',
+      }}
+    >
+      {token.icon ? (
+        <img src={token.icon} alt={`${token.symbol} logo`} style={{ width: 24, height: 24 }} />
+      ) : (
+        <div style={{ width: 24, height: 24, background: '#ccc', borderRadius: 4 }} />
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <strong>{token.symbol}</strong>
+        <span style={{ fontSize: '0.75rem', color: '#666' }}>{token.name}</span>
       </div>
-      <div style={{ fontSize: '0.875rem', marginTop: '0.25rem', display: 'flex', gap: '1rem' }}>
-        <div>Price: {core.priceUsd !== undefined ? `$${core.priceUsd.toFixed(2)}` : '-'}</div>
-        <div>Liq: {core.liqUsd !== undefined ? `$${core.liqUsd.toLocaleString()}` : '-'}</div>
-        <div>Vol24h: {core.vol24hUsd !== undefined ? `$${core.vol24hUsd.toLocaleString()}` : '-'}</div>
-        <div>Change24h: {core.priceChange24hPct !== undefined ? `${core.priceChange24hPct.toFixed(2)}%` : '-'}</div>
-      </div>
-      <div style={{ marginTop: '0.25rem' }}>
-        Pools:
-        <ul style={{ margin: 0, paddingLeft: '1.25rem' }}>
-          {pools.map((p) => (
-            <li key={p.pairId}>{p.dex} {p.base}/{p.quote}</li>
-          ))}
-        </ul>
-      </div>
+      <div style={{ fontSize: '0.875rem', color: '#666' }}>{chain}</div>
+      <div>{core.priceUsd !== undefined ? `$${core.priceUsd.toFixed(4)}` : '-'}</div>
+      <div>{core.liqUsd !== undefined ? `$${core.liqUsd.toLocaleString()}` : '-'}</div>
+      <div>{core.vol24hUsd !== undefined ? `$${core.vol24hUsd.toLocaleString()}` : '-'}</div>
+      <div>{core.priceChange24hPct !== undefined ? `${core.priceChange24hPct.toFixed(2)}%` : '-'}</div>
+      <div>{pools.length}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- validate search inputs and handle API errors with retry and rate limit backoff
- show provider badge, skeleton rows, and structured result list
- expose search result navigation to token pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c688751408323aec9c12e2c61262e