### PR TITLE
Implement deterministic list ranking with provider docs

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -15,3 +15,8 @@ Normalized field mapping for data providers.
 ## Notes
 - All client requests go through Netlify Functions.
 - Missing values default to `undefined`; clients handle gracefully.
+- Lists endpoints (`trending`, `discovery`, `leaderboard`) pull raw entries
+  from the active provider and normalize to a common shape. Each entry may
+  include a `promoted` flag. A composite `score` is computed from volume
+  change, price change, and trade count to provide a deterministic ranking
+  across chains and windows.

--- a/netlify/functions/lists.ts
+++ b/netlify/functions/lists.ts
@@ -1,5 +1,11 @@
 import type { Handler } from '@netlify/functions';
-import type { ListsResponse, ApiError, ListType, Window } from '../../src/lib/types';
+import type {
+  ListsResponse,
+  ApiError,
+  ListType,
+  Window,
+  ListItem,
+} from '../../src/lib/types';
 import fs from 'fs/promises';
 
 const FIXTURES: Record<string, string> = {
@@ -40,6 +46,31 @@ async function fetchJson(url: string): Promise<any> {
   }
 }
 
+function rank(items: ListItem[]): void {
+  let maxVol = 0;
+  let maxPrice = 0;
+  let maxTrades = 0;
+  for (const it of items) {
+    if (it.volWindowUsd && it.volWindowUsd > maxVol) maxVol = it.volWindowUsd;
+    if (it.priceChangePct !== undefined) {
+      const p = Math.abs(it.priceChangePct);
+      if (p > maxPrice) maxPrice = p;
+    }
+    if (it.tradesWindow && it.tradesWindow > maxTrades) maxTrades = it.tradesWindow;
+  }
+  for (const it of items) {
+    const volScore = maxVol ? (it.volWindowUsd || 0) / maxVol : 0;
+    const priceScore = maxPrice ? Math.abs(it.priceChangePct || 0) / maxPrice : 0;
+    const tradeScore = maxTrades ? (it.tradesWindow || 0) / maxTrades : 0;
+    it.score = 0.5 * volScore + 0.3 * priceScore + 0.2 * tradeScore;
+  }
+  items.sort((a, b) => {
+    const diff = (b.score || 0) - (a.score || 0);
+    if (diff !== 0) return diff;
+    return a.pairId.localeCompare(b.pairId);
+  });
+}
+
 export const handler: Handler = async (event) => {
   const chain = event.queryStringParameters?.chain;
   const type = event.queryStringParameters?.type as ListType | undefined;
@@ -54,7 +85,7 @@ export const handler: Handler = async (event) => {
 
   const headers = {
     'Content-Type': 'application/json',
-    'Cache-Control': 'public, max-age=30, stale-while-revalidate=60',
+    'Cache-Control': 'public, max-age=60, stale-while-revalidate=60',
   };
 
   const key = `${type}:${chain}:${window}`;
@@ -66,6 +97,7 @@ export const handler: Handler = async (event) => {
     }
     try {
       const data = await readFixture(path);
+      rank(data.items);
       if (limit !== undefined) data.items = data.items.slice(0, limit);
       return { statusCode: 200, headers, body: JSON.stringify(data) };
     } catch {
@@ -78,6 +110,8 @@ export const handler: Handler = async (event) => {
     const dsUrl = `${DS_API_BASE}/lists/${type}?chain=${chain}&window=${window}${limit ? `&limit=${limit}` : ''}`;
     const ds = await fetchJson(dsUrl);
     if (ds && Object.keys(ds).length) {
+      rank(ds.items || []);
+      if (limit !== undefined) ds.items = ds.items.slice(0, limit);
       ds.provider = 'ds';
       return { statusCode: 200, headers, body: JSON.stringify(ds) };
     }
@@ -87,6 +121,8 @@ export const handler: Handler = async (event) => {
       const gtUrl = `${GT_API_BASE}/networks/${chain}/${type}?window=${window}${limit ? `&limit=${limit}` : ''}`;
       const gt = await fetchJson(gtUrl);
       if (!gt || Object.keys(gt).length === 0) throw new Error('empty');
+      rank(gt.items || []);
+      if (limit !== undefined) gt.items = gt.items.slice(0, limit);
       gt.provider = 'gt';
       return { statusCode: 200, headers, body: JSON.stringify(gt) };
     } catch {


### PR DESCRIPTION
## Summary
- compute list scores from volume, price change, and trade count and sort deterministically
- expose 60s cache and limit support in lists function
- document list provider normalization and scoring

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c6dc925b08323a1bb3460f0916106