### PR TITLE
feat: show trending tokens and polish search page

### DIFF
--- a/src/copy/en.json
+++ b/src/copy/en.json
@@ -1,5 +1,5 @@
 {
-  "search_placeholder": "Token address",
+  "search_placeholder": "Enter token address",
   "no_results": "No results found",
   "no_pools": "No pools available",
   "loading": "Loading...",
@@ -7,5 +7,7 @@
   "error_invalid_address": "Invalid address",
   "error_rate_limit": "Too many requests, please slow down",
   "error_upstream": "Network error, please try again",
-  "retry": "Retry"
+  "retry": "Retry",
+  "results": "Results",
+  "trending_tokens": "Trending Tokens"
 }

--- a/src/features/lists/ListItem.tsx
+++ b/src/features/lists/ListItem.tsx
@@ -52,3 +52,24 @@ export default function ListItem({ item, rank, provider }: Props) {
     </div>
   );
 }
+
+export function ListItemSkeleton() {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '40px 1fr 80px 80px 80px 80px 80px 60px',
+        gap: '0.5rem',
+        padding: '0.5rem',
+        borderBottom: '1px solid #eee',
+      }}
+    >
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div
+          key={i}
+          style={{ height: 16, background: '#eee', borderRadius: 4 }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/features/search/SearchResultItem.tsx
+++ b/src/features/search/SearchResultItem.tsx
@@ -5,24 +5,16 @@ interface Props { result: SearchResult }
 
 export function SearchResultSkeleton() {
   return (
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: '40px 1fr 80px 80px 80px 80px 80px 60px',
-        gap: '0.5rem',
-        padding: '0.5rem',
-        borderBottom: '1px solid #eee'
-      }}
-    >
-      <div style={{ width: 24, height: 24, background: '#eee', borderRadius: 4 }} />
-      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
-      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
-      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
-      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
-      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
-      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
-      <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
-    </div>
+    <tr>
+      <td><div style={{ width: 24, height: 24, background: '#eee', borderRadius: 4 }} /></td>
+      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
+      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
+      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
+      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
+      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
+      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
+      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
+    </tr>
   );
 }
 
@@ -34,36 +26,32 @@ export default function SearchResultItem({ result }: Props) {
     navigate(`/t/${chain}/${token.address}/${pairId || ''}`);
   }
   return (
-    <div
+    <tr
       role="button"
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={(e) => { if (e.key === 'Enter') handleClick(); }}
-      style={{
-        display: 'grid',
-        gridTemplateColumns: '40px 1fr 80px 80px 80px 80px 80px 60px',
-        gap: '0.5rem',
-        padding: '0.5rem',
-        cursor: 'pointer',
-        borderBottom: '1px solid #eee',
-      }}
+      style={{ cursor: 'pointer' }}
     >
-      {token.icon ? (
-        <img src={token.icon} alt={`${token.symbol} logo`} style={{ width: 24, height: 24 }} />
-      ) : (
-        <div style={{ width: 24, height: 24, background: '#ccc', borderRadius: 4 }} />
-      )}
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <strong>{token.symbol}</strong>
-        <span style={{ fontSize: '0.75rem', color: '#666' }}>{token.name}</span>
-      </div>
-      <div style={{ fontSize: '0.875rem', color: '#666' }}>{chain}</div>
-      <div>{core.priceUsd !== undefined ? `$${core.priceUsd.toFixed(4)}` : '-'}</div>
-      <div>{core.liqUsd !== undefined ? `$${core.liqUsd.toLocaleString()}` : '-'}</div>
-      <div>{core.vol24hUsd !== undefined ? `$${core.vol24hUsd.toLocaleString()}` : '-'}</div>
-      <div>{core.priceChange24hPct !== undefined ? `${core.priceChange24hPct.toFixed(2)}%` : '-'}</div>
-      <div>{pools.length}</div>
-    </div>
+      <td>
+        {token.icon ? (
+          <img src={token.icon} alt={`${token.symbol} logo`} style={{ width: 24, height: 24 }} />
+        ) : (
+          <div style={{ width: 24, height: 24, background: '#ccc', borderRadius: 4 }} />
+        )}
+      </td>
+      <td>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <strong>{token.symbol}</strong>
+          <span style={{ fontSize: '0.75rem', color: '#666' }}>{token.name}</span>
+        </div>
+      </td>
+      <td style={{ fontSize: '0.875rem', color: '#666' }}>{chain}</td>
+      <td>{core.priceUsd !== undefined ? `$${core.priceUsd.toFixed(4)}` : '-'}</td>
+      <td>{core.liqUsd !== undefined ? `$${core.liqUsd.toLocaleString()}` : '-'}</td>
+      <td>{core.vol24hUsd !== undefined ? `$${core.vol24hUsd.toLocaleString()}` : '-'}</td>
+      <td>{core.priceChange24hPct !== undefined ? `${core.priceChange24hPct.toFixed(2)}%` : '-'}</td>
+      <td>{pools.length}</td>
+    </tr>
   );
 }
-

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,14 @@
-import type { SearchResponse, ApiError, PairsResponse, OHLCResponse, TradesResponse, Timeframe } from './types';
+import type {
+  SearchResponse,
+  ApiError,
+  PairsResponse,
+  OHLCResponse,
+  TradesResponse,
+  Timeframe,
+  ListsResponse,
+  ListType,
+  Window,
+} from './types';
 import {
   getSearchCache,
   setSearchCache,
@@ -98,5 +108,25 @@ export async function trades(pairId: string, provider?: string): Promise<TradesR
   }
   setTradesCache(key, data);
   return data as TradesResponse;
+}
+
+export async function lists(
+  params: { chain: string; type: ListType; window: Window; limit?: number }
+): Promise<ListsResponse | ApiError> {
+  const url = new URL(`${BASE}/lists`, window.location.origin);
+  url.searchParams.set('chain', params.chain);
+  url.searchParams.set('type', params.type);
+  url.searchParams.set('window', params.window);
+  if (params.limit) url.searchParams.set('limit', params.limit.toString());
+  try {
+    const res = await fetch(url.toString());
+    const data = await res.json();
+    if (!res.ok) {
+      return data.error ? data : { error: 'upstream_error', provider: 'none' };
+    }
+    return data as ListsResponse;
+  } catch {
+    return { error: 'upstream_error', provider: 'none' };
+  }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,3 +124,53 @@ main.with-tabs {
 .view-tab:focus-visible {
   outline: 2px solid var(--color-accent);
 }
+
+input:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--color-accent);
+}
+
+.search-results-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+.search-results-table th,
+.search-results-table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #eee;
+  text-align: left;
+}
+
+.search-results-table th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  font-weight: bold;
+}
+
+.provider-badge {
+  font-size: 0.75rem;
+  border: 1px solid #999;
+  padding: 0 0.25rem;
+}
+
+.error-banner {
+  background: #fee;
+  color: #900;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.no-results {
+  color: #666;
+  margin-top: 0.5rem;
+}
+
+.trending-section {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- show Trending Tokens panel powered by lists API when landing or after empty searches
- redesign search results into semantic table and move provider badge to heading
- improve search UX with better placeholder text, skeletons, and focus styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c9aed14188323b85300260019bab4