### PR TITLE
Fix lists endpoint, harden chart APIs, add quick search

### DIFF
--- a/netlify/functions/lists.ts
+++ b/netlify/functions/lists.ts
@@ -108,8 +108,11 @@ export const handler: Handler = async (event) => {
   try {
     const gtUrl = `${GT_API_BASE}/networks/${chain}/${type}?window=${window}${limit ? `&limit=${limit}` : ''}`;
     const gt = await fetchJson(gtUrl);
-    const dataArray = gt.data || gt.items || [];
-    if (!Array.isArray(dataArray) || dataArray.length === 0) throw new Error('empty');
+    const dataArray = Array.isArray(gt?.data)
+      ? gt.data
+      : Array.isArray(gt?.items)
+      ? gt.items
+      : [];
 
     const items: ListItem[] = dataArray.map((d: any) => {
       const attr = d.attributes || {};

--- a/netlify/functions/ohlc.ts
+++ b/netlify/functions/ohlc.ts
@@ -79,8 +79,8 @@ export const handler: Handler = async (event) => {
   try {
     if (forceProvider !== 'gt') {
       const ds = await fetchJson(`${DS_API_BASE}/dex/pairs/${pairId}/candles?timeframe=${tf}`);
-      if (!ds || !Array.isArray(ds.candles)) throw new Error('empty');
-      const candles = ds.candles.map((c: any) => ({
+      const dsList = Array.isArray(ds?.candles) ? ds.candles : [];
+      const candles = dsList.map((c: any) => ({
         t: Number(c.t ?? c.timestamp ?? c[0]),
         o: Number(c.o ?? c.open ?? c[1]),
         h: Number(c.h ?? c.high ?? c[2]),
@@ -99,9 +99,13 @@ export const handler: Handler = async (event) => {
     }
     try {
       const gt = await fetchJson(`${GT_API_BASE}/pools/${pairId}/ohlcv/${tf}`);
-      const list =
-        gt?.data?.attributes?.ohlcv_list || gt?.data || gt?.candles || [];
-      if (!Array.isArray(list) || list.length === 0) throw new Error('empty');
+      const list = Array.isArray(gt?.data?.attributes?.ohlcv_list)
+        ? gt.data.attributes.ohlcv_list
+        : Array.isArray(gt?.data)
+        ? gt.data
+        : Array.isArray(gt?.candles)
+        ? gt.candles
+        : [];
       const candles = list.map((c: any) => ({
         t: Number(c[0] ?? c.t ?? c.timestamp),
         o: Number(c[1] ?? c.o ?? c.open),

--- a/netlify/functions/trades.ts
+++ b/netlify/functions/trades.ts
@@ -68,8 +68,8 @@ export const handler: Handler = async (event) => {
   try {
     if (forceProvider !== 'gt') {
       const ds = await fetchJson(`${DS_API_BASE}/dex/pairs/${pairId}/trades`);
-      if (!ds || !Array.isArray(ds.trades)) throw new Error('empty');
-      const trades: Trade[] = ds.trades.map((t: any) => ({
+      const dsList = Array.isArray(ds?.trades) ? ds.trades : [];
+      const trades: Trade[] = dsList.map((t: any) => ({
         ts: Number(t.ts ?? t.time ?? t.blockTimestamp ?? t[0]),
         side: (t.side || t.type || t.tradeType || '').toLowerCase() === 'sell' ? 'sell' : 'buy',
         price: Number(t.priceUsd ?? t.price_usd ?? t.price ?? t[1] ?? 0),
@@ -103,8 +103,11 @@ export const handler: Handler = async (event) => {
     }
     try {
       const gt = await fetchJson(`${GT_API_BASE}/pools/${pairId}/trades`);
-      const list = gt.data || gt.trades || [];
-      if (!Array.isArray(list)) throw new Error('empty');
+      const list = Array.isArray(gt?.data)
+        ? gt.data
+        : Array.isArray(gt?.trades)
+        ? gt.trades
+        : [];
       const trades: Trade[] = list.map((d: any) => {
         const t = d.attributes || d;
         return {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,19 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { search as apiSearch } from '../lib/api';
+import type { SearchResult } from '../lib/types';
 
 export default function Header() {
   const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const searchRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -44,11 +53,74 @@ export default function Header() {
   }, [menuOpen]);
 
   function handleSearchClick() {
-    navigate('/');
-    setTimeout(() => {
-      const input = document.getElementById('search-input') as HTMLInputElement | null;
-      input?.focus();
-    }, 0);
+    setSearchOpen(true);
+  }
+
+  useEffect(() => {
+    if (!searchOpen) return;
+    inputRef.current?.focus();
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setSearchOpen(false);
+      } else if (e.key === 'Tab' && searchRef.current) {
+        const focusables = searchRef.current.querySelectorAll<HTMLElement>('input, button');
+        if (focusables.length === 0) return;
+        const firstEl = focusables[0];
+        const lastEl = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === firstEl) {
+          e.preventDefault();
+          lastEl.focus();
+        } else if (!e.shiftKey && document.activeElement === lastEl) {
+          e.preventDefault();
+          firstEl.focus();
+        }
+      }
+    }
+
+    function handleClickOutside(e: MouseEvent) {
+      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
+        setSearchOpen(false);
+      }
+    }
+
+    document.addEventListener('keydown', handleKey);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [searchOpen]);
+
+  function isValid(addr: string) {
+    return /^0x[a-fA-F0-9]{40}$/.test(addr.trim());
+  }
+
+  async function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isValid(query)) {
+      setError('invalid');
+      setResults([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    const data = await apiSearch(query);
+    setLoading(false);
+    if ('error' in data) {
+      setResults([]);
+      setError(data.error);
+    } else {
+      setResults(Array.isArray(data.results) ? data.results : []);
+    }
+  }
+
+  function handleResultClick(r: SearchResult) {
+    const pairId = r.pools[0]?.pairId || '';
+    navigate(`/t/${r.chain}/${r.token.address}/${pairId}`);
+    setSearchOpen(false);
+    setQuery('');
+    setResults([]);
   }
 
   return (
@@ -63,9 +135,80 @@ export default function Header() {
       >
         ☰
       </button>
-      <button type="button" className="search-pill" onClick={handleSearchClick} aria-label="Search">
+      <button
+        type="button"
+        className="search-pill"
+        onClick={handleSearchClick}
+        aria-label="Search"
+        aria-expanded={searchOpen}
+        aria-haspopup="dialog"
+      >
         Search
       </button>
+      {searchOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          ref={searchRef}
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: 'rgba(0,0,0,0.4)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+        >
+          <div style={{ background: '#fff', padding: '1rem', minWidth: '300px' }}>
+            <form onSubmit={handleSearch} style={{ marginBottom: '0.5rem' }}>
+              <label htmlFor="quick-search-input" style={{ position: 'absolute', left: '-10000px' }}>
+                Search
+              </label>
+              <input
+                id="quick-search-input"
+                ref={inputRef}
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setError(null);
+                }}
+                style={{ width: '100%', padding: '0.5rem' }}
+              />
+            </form>
+            {error === 'invalid' && (
+              <div style={{ color: 'red', fontSize: '0.875rem' }}>Invalid address</div>
+            )}
+            {loading && <div style={{ fontSize: '0.875rem' }}>Loading...</div>}
+            {!loading && results.length > 0 && (
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {results.map((r) => (
+                  <li key={r.token.address} style={{ marginBottom: '0.5rem' }}>
+                    <button
+                      type="button"
+                      onClick={() => handleResultClick(r)}
+                      style={{ width: '100%', textAlign: 'left' }}
+                    >
+                      <strong>{r.token.symbol}</strong> {r.token.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {!loading && results.length === 0 && !error && (
+              <div style={{ fontSize: '0.875rem' }}>No results</div>
+            )}
+            <div style={{ marginTop: '0.5rem', textAlign: 'right' }}>
+              <button type="button" onClick={() => setSearchOpen(false)}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       {menuOpen && (
         <nav id="main-menu" ref={menuRef} className="menu-sheet" aria-label="Main menu">
           <ul>

--- a/src/copy/en.json
+++ b/src/copy/en.json
@@ -9,5 +9,5 @@
   "error_upstream": "Network error, please try again",
   "retry": "Retry",
   "results": "Results",
-  "trending_tokens": "Trending Tokens"
+  "trending_tokens": "Trending tokens last 24 h"
 }

--- a/src/features/chart/ChartPage.tsx
+++ b/src/features/chart/ChartPage.tsx
@@ -8,14 +8,7 @@ import DetailView from './DetailView';
 import copy from '../../copy/en.json';
 
 // Views for chart page
-const views = ['chart', 'depth', 'trades', 'detail'] as const;
-type View = typeof views[number];
-const viewLabels: Record<View, string> = {
-  chart: 'Chart',
-  depth: 'Chart + TXs',
-  trades: 'Trades',
-  detail: 'Detail',
-};
+type View = 'chart' | 'depth' | 'trades' | 'detail';
 
 export default function ChartPage() {
   const { chain, address, pairId } = useParams<{ chain: string; address: string; pairId?: string }>();
@@ -23,7 +16,7 @@ export default function ChartPage() {
   const [token, setToken] = useState<TokenMeta | null>(null);
   const [pools, setPools] = useState<PoolSummary[]>([]);
   const [currentPair, setCurrentPair] = useState<string | undefined>(pairId);
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const view = (searchParams.get('view') as View) || 'chart';
   const [xDomain, setXDomain] = useState<[number, number] | null>(null);
   const [loading, setLoading] = useState(true);
@@ -86,26 +79,6 @@ export default function ChartPage() {
 
       {!loading && !error && pools.length > 0 && (
         <>
-          <div className="view-tabs" role="tablist" aria-label="Chart sections">
-            {views.map((v) => (
-              <button
-                key={v}
-                role="tab"
-                aria-selected={view === v}
-                tabIndex={view === v ? 0 : -1}
-                onClick={() => {
-                  setSearchParams((sp) => {
-                    sp.set('view', v);
-                    return sp;
-                  });
-                }}
-                className="view-tab"
-              >
-                {viewLabels[v]}
-              </button>
-            ))}
-          </div>
-
           {view !== 'detail' && (
             <PoolSwitcher pools={pools} current={currentPair} onSwitch={handlePoolSwitch} />
           )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -86,6 +86,9 @@ export async function ohlc(
     err.status = res.status;
     throw err;
   }
+  if (!Array.isArray((data as any).candles)) {
+    (data as any).candles = [];
+  }
   setOHLCCache(key, data);
   return data as OHLCResponse;
 }
@@ -105,6 +108,9 @@ export async function trades(pairId: string, provider?: string): Promise<TradesR
     const err: any = new Error('api error');
     err.status = res.status;
     throw err;
+  }
+  if (!Array.isArray((data as any).trades)) {
+    (data as any).trades = [];
   }
   setTradesCache(key, data);
   return data as TradesResponse;


### PR DESCRIPTION
## Summary
- use GeckoTerminal only for list data and parse into ListItem
- ensure ohlc/trades always return arrays and guard chart rendering
- remove duplicate chart tabs and add header quick search modal

## Testing
- `npm run build`
- `USE_FIXTURES=true node -e "require('ts-node/register'); const {handler}=require('./netlify/functions/lists.ts'); handler({queryStringParameters:{chain:'ethereum',type:'trending',window:'1h',limit:'2'}}).then(r=>console.log(r));"`
- `USE_FIXTURES=true node -e "require('ts-node/register'); const {handler}=require('./netlify/functions/ohlc.ts'); handler({queryStringParameters:{pairId:'0xabc',tf:'1m'}}).then(r=>console.log(r));"`
- `USE_FIXTURES=true node -e "require('ts-node/register'); const {handler}=require('./netlify/functions/trades.ts'); handler({queryStringParameters:{pairId:'0xabc'}}).then(r=>console.log(r));"`


------
https://chatgpt.com/codex/tasks/task_e_689ca8c525f88323aa85dec5ac3ada58