### PR TITLE
Add GeckoTerminal fallbacks and network-aware APIs

### DIFF
--- a/netlify/functions/ohlc.ts
+++ b/netlify/functions/ohlc.ts
@@ -40,9 +40,10 @@ async function fetchJson(url: string): Promise<any> {
 export const handler: Handler = async (event) => {
   const pairId = event.queryStringParameters?.pairId;
   const tf = event.queryStringParameters?.tf as Timeframe | undefined;
+  const chain = event.queryStringParameters?.chain;
   const forceProvider = event.queryStringParameters?.provider as Provider | undefined;
 
-  if (!isValidPair(pairId) || !isValidTf(tf)) {
+  if (!isValidPair(pairId) || !isValidTf(tf) || !chain) {
     const body: ApiError = { error: 'invalid_request', provider: 'none' };
     return { statusCode: 400, body: JSON.stringify(body) };
   }
@@ -135,7 +136,7 @@ export const handler: Handler = async (event) => {
 
   if (candles.length === 0 && forceProvider !== 'ds') {
     try {
-      const gt = await fetchJson(`${GT_API_BASE}/pools/${pairId}/ohlcv/${tf}`);
+      const gt = await fetchJson(`${GT_API_BASE}/networks/${chain}/pools/${pairId}/ohlcv/${tf}`);
       const list = Array.isArray(gt?.data?.attributes?.ohlcv_list)
         ? gt.data.attributes.ohlcv_list
         : Array.isArray(gt?.data)

--- a/netlify/functions/trades.ts
+++ b/netlify/functions/trades.ts
@@ -35,9 +35,10 @@ async function fetchJson(url: string): Promise<any> {
 
 export const handler: Handler = async (event) => {
   const pairId = event.queryStringParameters?.pairId;
+  const chain = event.queryStringParameters?.chain;
   const forceProvider = event.queryStringParameters?.provider as Provider | undefined;
 
-  if (!isValidPair(pairId)) {
+  if (!isValidPair(pairId) || !chain) {
     const body: ApiError = { error: 'invalid_request', provider: 'none' };
     return { statusCode: 400, body: JSON.stringify(body) };
   }
@@ -149,7 +150,7 @@ export const handler: Handler = async (event) => {
 
   if (trades.length === 0 && forceProvider !== 'ds') {
     try {
-      const gt = await fetchJson(`${GT_API_BASE}/pools/${pairId}/trades`);
+      const gt = await fetchJson(`${GT_API_BASE}/networks/${chain}/pools/${pairId}/trades`);
       const list = Array.isArray(gt?.data)
         ? gt.data
         : Array.isArray(gt?.trades)

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,8 +1,8 @@
 import { lazy } from 'react';
 import { RouteObject } from 'react-router-dom';
+import Chart from '../pages/Chart';
 
 const Home = lazy(() => import('../pages/Home'));
-const Chart = lazy(() => import('../pages/Chart'));
 const Lists = lazy(() => import('../pages/Lists'));
 
 export const routes: RouteObject[] = [

--- a/src/features/chart/ChartOnlyView.tsx
+++ b/src/features/chart/ChartOnlyView.tsx
@@ -18,17 +18,17 @@ export default function ChartOnlyView({ pairId, chain, tf, xDomain, onXDomainCha
 
   useEffect(() => {
     if (showMarkers) {
-      const m = getTradeMarkers(pairId);
+      const m = getTradeMarkers(pairId, chain);
       setMarkers(m);
       setNoTrades(m.length === 0);
     }
-  }, [pairId, showMarkers]);
+  }, [pairId, chain, showMarkers]);
 
   function handleToggle() {
     setShowMarkers((v) => {
       const next = !v;
       if (next) {
-        setMarkers(getTradeMarkers(pairId));
+        setMarkers(getTradeMarkers(pairId, chain));
       } else {
         setMarkers([]);
       }

--- a/src/features/chart/PriceChart.tsx
+++ b/src/features/chart/PriceChart.tsx
@@ -109,11 +109,11 @@ export default function PriceChart({ pairId, tf, xDomain, onXDomainChange, marke
   }, [markers]);
 
   useEffect(() => {
-    if (!pairId) return;
+    if (!pairId || !chain) return;
     let candles: Candle[] = [];
 
     const poller = createPoller(async () => {
-      const data = await ohlc(pairId, tf);
+      const data = await ohlc(pairId, tf, chain);
       candles = data.candles;
       if (data.rollupHint === 'client' && data.tf !== tf) {
         candles = rollupCandles(candles, data.tf, tf);
@@ -147,7 +147,7 @@ export default function PriceChart({ pairId, tf, xDomain, onXDomainChange, marke
     poller.start();
 
     const tradesPoller = createPoller(async () => {
-      const tr = await trades(pairId);
+      const tr = await trades(pairId, chain);
       if (tr && Array.isArray(tr.trades) && tr.trades.length > 0) {
         // noop: data is cached in trades() and used elsewhere
       }
@@ -161,7 +161,7 @@ export default function PriceChart({ pairId, tf, xDomain, onXDomainChange, marke
       poller.stop();
       tradesPoller.stop();
     };
-  }, [pairId, tf]);
+  }, [pairId, tf, chain]);
 
   return (
     <div style={{ position: 'relative' }}>

--- a/src/features/trades/TradeMarkers.ts
+++ b/src/features/trades/TradeMarkers.ts
@@ -46,8 +46,13 @@ export function computeTradeMarkers(trades: Trade[], limit = MAX_MARKERS): Trade
   return markers.slice(-limit);
 }
 
-export function getTradeMarkers(pairId: string, limit = MAX_MARKERS): TradeMarkerCluster[] {
-  const cached = getTradesCache(pairId);
+export function getTradeMarkers(
+  pairId: string,
+  chain?: string,
+  limit = MAX_MARKERS
+): TradeMarkerCluster[] {
+  const key = chain ? `${chain}:${pairId}` : pairId;
+  const cached = getTradesCache(key);
   if (!cached) return [];
   return computeTradeMarkers(cached.trades, limit);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -71,15 +71,17 @@ export async function pairs(
 export async function ohlc(
   pairId: string,
   tf: Timeframe,
+  chain: string,
   provider?: string
 ): Promise<OHLCResponse> {
-  const key = `${pairId}:${tf}`;
+  const key = `${chain}:${pairId}:${tf}`;
   const cached = getOHLCCache(key);
   if (cached) return cached;
 
   const url = new URL(`${BASE}/ohlc`, window.location.origin);
   url.searchParams.set('pairId', pairId);
   url.searchParams.set('tf', tf);
+  url.searchParams.set('chain', chain);
   if (provider) url.searchParams.set('provider', provider);
 
   const res = await fetch(url.toString());
@@ -96,13 +98,18 @@ export async function ohlc(
   return data as OHLCResponse;
 }
 
-export async function trades(pairId: string, provider?: string): Promise<TradesResponse> {
-  const key = pairId;
+export async function trades(
+  pairId: string,
+  chain: string,
+  provider?: string
+): Promise<TradesResponse> {
+  const key = `${chain}:${pairId}`;
   const cached = getTradesCache(key);
   if (cached) return cached;
 
   const url = new URL(`${BASE}/trades`, window.location.origin);
   url.searchParams.set('pairId', pairId);
+  url.searchParams.set('chain', chain);
   if (provider) url.searchParams.set('provider', provider);
 
   const res = await fetch(url.toString());


### PR DESCRIPTION
## Summary
- Load Chart page without lazy chunk to fix missing import error
- Pass network to OHLC and trade APIs and fall back to GeckoTerminal endpoints
- Use Dexscreener metrics when CoinGecko token data is unavailable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689cc6bc952c8323ac41beabe9ed202c