### PR TITLE
feat: discover pool addresses and improve GT fallbacks

### DIFF
--- a/netlify/functions/lists.ts
+++ b/netlify/functions/lists.ts
@@ -20,6 +20,11 @@ const GT_API_KEY = process.env.GT_API_KEY || '';
 const DS_API_BASE = process.env.DS_API_BASE || '';
 const CG_API_BASE = process.env.COINGECKO_API_BASE || '';
 const CG_API_KEY = process.env.COINGECKO_API_KEY || '';
+const DEBUG = process.env.DEBUG_LOGS === 'true';
+
+function log(...args: any[]) {
+  if (DEBUG) console.log('[lists]', ...args);
+}
 
 function isValidType(t?: string): t is ListType {
   return t === 'trending' || t === 'discovery' || t === 'leaderboard';
@@ -89,6 +94,8 @@ export const handler: Handler = async (event) => {
   const window = event.queryStringParameters?.window as Window | undefined;
   const limitParam = event.queryStringParameters?.limit;
   const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+
+  log('params', { chain, type, window, limit });
 
   if (!isValidType(type) || !isValidWindow(window)) {
     const body: ApiError = { error: 'invalid_request', provider: 'none' };
@@ -178,6 +185,7 @@ export const handler: Handler = async (event) => {
       if (items.length > 0) {
         rank(items);
         provider = 'gt';
+        log('gt items', items.length);
       }
     } catch {
       // noop, will fall back to DS
@@ -231,6 +239,7 @@ export const handler: Handler = async (event) => {
       if (items.length > 0) {
         rank(items);
         provider = 'cg';
+        log('cg items', items.length);
       }
     } catch {
       // ignore, fall through
@@ -288,6 +297,7 @@ export const handler: Handler = async (event) => {
     if (items.length > 0) {
       rank(items);
       provider = 'ds';
+      log('ds items', items.length);
     }
   }
 

--- a/netlify/functions/pairs.ts
+++ b/netlify/functions/pairs.ts
@@ -7,6 +7,12 @@ const GT_FIXTURE = '../../fixtures/pairs-gt.json';
 const USE_FIXTURES = process.env.USE_FIXTURES === 'true';
 const DS_API_BASE = process.env.DS_API_BASE || '';
 const GT_API_BASE = process.env.GT_API_BASE || '';
+const SUPPORTED_CHAINS = new Set(Object.values(CHAIN_ID_MAP));
+
+function log(...args: any[]) {
+  if (DEBUG) console.log('[pairs]', ...args);
+}
+const DEBUG = process.env.DEBUG_LOGS === 'true';
 
 // Map numeric chain IDs from Dexscreener to chain slugs used in the app.
 const CHAIN_ID_MAP: Record<string, string> = {
@@ -55,8 +61,14 @@ export const handler: Handler = async (event) => {
   const address = event.queryStringParameters?.address;
   const forceProvider = event.queryStringParameters?.provider as Provider | undefined;
 
+  log('params', { chain, address, forceProvider });
+
   if (!isValidChain(chain) || !isValidAddress(address)) {
     const body: ApiError = { error: 'invalid_request', provider: 'none' };
+    return { statusCode: 400, body: JSON.stringify(body) };
+  }
+  if (!SUPPORTED_CHAINS.has(chain)) {
+    const body: ApiError = { error: 'unsupported_network', provider: 'none' };
     return { statusCode: 400, body: JSON.stringify(body) };
   }
 
@@ -98,48 +110,91 @@ export const handler: Handler = async (event) => {
         icon: tokenMeta.icon || tokenMeta.imageUrl || undefined,
       };
 
-      const pools: PoolSummary[] = ds.pairs.map((p: any) => ({
-        pairId: p.pairId || p.pairAddress,
-        dex: p.dexId,
-        base: p.baseToken?.symbol,
-        quote: p.quoteToken?.symbol,
-        chain: mapChainId(p.chainId),
-        poolAddress: p.pairAddress || p.liquidityPoolAddress,
-      }));
+      const pools: PoolSummary[] = [];
+      for (const p of ds.pairs) {
+        const chainSlug = mapChainId(p.chainId);
+        let poolAddr = p.pairAddress || p.liquidityPoolAddress;
+        if (!isValidAddress(poolAddr)) {
+          try {
+            const detail = await fetchJson(
+              `${DS_API_BASE}/dex/pairs/${chainSlug}/${p.pairId || p.pairAddress}`
+            );
+            poolAddr =
+              detail?.pair?.pairAddress || detail?.pair?.address || detail?.pairAddress;
+          } catch {
+            // ignore
+          }
+        }
+        pools.push({
+          pairId: p.pairId || p.pairAddress,
+          dex: p.dexId,
+          base: p.baseToken?.symbol,
+          quote: p.quoteToken?.symbol,
+          chain: chainSlug,
+          poolAddress: isValidAddress(poolAddr) ? poolAddr : undefined,
+        });
+      }
+      const missing = pools.some((p) => !p.poolAddress);
+      if (missing) {
+        try {
+          const gtPools = await fetchJson(
+            `${GT_API_BASE}/networks/${chain}/tokens/${address}/pools`
+          );
+          const arr = Array.isArray(gtPools?.data) ? gtPools.data : [];
+          for (const d of arr) {
+            const attr = d.attributes || {};
+            if (!isValidAddress(attr.pool_address)) continue;
+            pools.push({
+              pairId: d.id,
+              dex: attr.dex || attr.name || '',
+              base: attr.base_token?.symbol,
+              quote: attr.quote_token?.symbol,
+              chain: chain!,
+              poolAddress: attr.pool_address,
+            });
+          }
+        } catch {
+          // ignore
+        }
+      }
 
+      log('dexscreener pools', pools.length);
       const bodyRes: PairsResponse = { token, pools, provider: 'ds' };
       return { statusCode: 200, headers, body: JSON.stringify(bodyRes) };
     }
     throw new Error('force gt');
   } catch {
+    log('ds branch failed');
     if (forceProvider === 'ds') {
       const body: ApiError = { error: 'upstream_error', provider: 'none' };
       return { statusCode: 500, headers, body: JSON.stringify(body) };
     }
     try {
-      const gt = await fetchJson(`${GT_API_BASE}/networks/${chain}/tokens/${address}`);
+      const tokenResp = await fetchJson(`${GT_API_BASE}/networks/${chain}/tokens/${address}`);
+      const poolsResp = await fetchJson(
+        `${GT_API_BASE}/networks/${chain}/tokens/${address}/pools`
+      );
       const pools: PoolSummary[] = [];
-      if (Array.isArray(gt.included)) {
-        for (const inc of gt.included) {
-          if (inc.type !== 'pool') continue;
-          const attr = inc.attributes || {};
-          pools.push({
-            pairId: inc.id,
-            dex: attr.dex || attr.name || '',
-            base: attr.base_token?.symbol,
-            quote: attr.quote_token?.symbol,
-            chain: chain as string,
-            poolAddress: attr.address || inc.id,
-          });
-        }
+      const arr = Array.isArray(poolsResp?.data) ? poolsResp.data : [];
+      for (const d of arr) {
+        const attr = d.attributes || {};
+        pools.push({
+          pairId: d.id,
+          dex: attr.dex || attr.name || '',
+          base: attr.base_token?.symbol,
+          quote: attr.quote_token?.symbol,
+          chain: chain as string,
+          poolAddress: attr.pool_address,
+        });
       }
-      const attr = gt.data?.attributes || {};
+      const attr = tokenResp.data?.attributes || {};
       const token: TokenMeta = {
         address: attr.address || address,
         symbol: attr.symbol || '',
         name: attr.name || '',
         icon: attr.image_url || undefined,
       };
+      log('gt pools', pools.length);
       const bodyRes: PairsResponse = { token, pools, provider: 'gt' };
       if (!pools.length) throw new Error('empty');
       return { statusCode: 200, headers, body: JSON.stringify(bodyRes) };

--- a/netlify/functions/search.ts
+++ b/netlify/functions/search.ts
@@ -16,6 +16,11 @@ const DS_API_BASE = process.env.DS_API_BASE || '';
 const GT_API_BASE = process.env.GT_API_BASE || '';
 const CG_API_BASE = process.env.COINGECKO_API_BASE || '';
 const CG_API_KEY = process.env.COINGECKO_API_KEY || '';
+const DEBUG = process.env.DEBUG_LOGS === 'true';
+
+function log(...args: any[]) {
+  if (DEBUG) console.log('[search]', ...args);
+}
 
 function isValidAddress(addr?: string): addr is string {
   return !!addr && /^0x[a-fA-F0-9]{40}$/.test(addr);
@@ -97,6 +102,7 @@ export const handler: Handler = async (event) => {
   }
 
   try {
+    log('params', { query, chain, forceProvider });
     if (forceProvider === 'cg') {
       if (!isValidChain(chain) || !CG_API_BASE || !CG_API_KEY) {
         throw new Error('force gt');
@@ -147,8 +153,9 @@ export const handler: Handler = async (event) => {
       }
 
       const tokenMeta = ds.token || ds.pairs[0]?.baseToken || {};
-      const results = ds.pairs.map((pair: any) => {
-        const chain = mapChainId(pair.chainId);
+      const results: SearchResult[] = [];
+      for (const pair of ds.pairs) {
+        const chainSlug = mapChainId(pair.chainId);
         const core = {
           priceUsd:
             pair.priceUsd !== undefined ? Number(pair.priceUsd) : undefined,
@@ -181,8 +188,34 @@ export const handler: Handler = async (event) => {
               ? Number(pair.priceChange.h24)
               : undefined,
         };
-        return {
-          chain,
+        let poolAddr = pair.pairAddress || pair.liquidityPoolAddress;
+        if (!isValidAddress(poolAddr)) {
+          try {
+            const detail = await fetchJson(
+              `${DS_API_BASE}/dex/pairs/${chainSlug}/${
+                pair.pairId || pair.pairAddress
+              }`
+            );
+            poolAddr =
+              detail?.pair?.pairAddress || detail?.pair?.address || detail?.pairAddress;
+          } catch {
+            // ignore
+          }
+        }
+        if (!isValidAddress(poolAddr)) {
+          try {
+            const gt = await fetchJson(
+              `${GT_API_BASE}/networks/${chainSlug}/tokens/${pair.baseToken?.address || query}/pools`
+            );
+            const first = gt?.data && gt.data[0];
+            poolAddr = first?.attributes?.pool_address;
+          } catch {
+            // ignore
+          }
+        }
+
+        results.push({
+          chain: chainSlug,
           token: {
             address: tokenMeta.address || pair.baseToken?.address || query,
             symbol: tokenMeta.symbol || pair.baseToken?.symbol || '',
@@ -200,29 +233,76 @@ export const handler: Handler = async (event) => {
               dex: pair.dexId,
               base: pair.baseToken?.symbol,
               quote: pair.quoteToken?.symbol,
-              chain,
-              poolAddress: pair.pairAddress || pair.liquidityPoolAddress,
+              chain: chainSlug,
+              poolAddress: isValidAddress(poolAddr) ? poolAddr : undefined,
             },
           ],
           provider: 'ds',
-        };
-      });
+        });
+      }
 
+      log('dexscreener results', results.length);
       const bodyRes: SearchResponse = { query, results };
       return { statusCode: 200, headers, body: JSON.stringify(bodyRes) };
     }
     throw new Error('force gt');
   } catch {
+    log('ds branch failed');
     if (forceProvider === 'ds') {
       const body: ApiError = { error: 'upstream_error', provider: 'none' };
       return { statusCode: 500, headers, body: JSON.stringify(body) };
     }
     try {
       const gt = await fetchJson(`${GT_API_BASE}/search/pairs?query=${query}`);
-      if (!gt || Object.keys(gt).length === 0) throw new Error('empty');
-      gt.provider = 'gt';
-      gt.query = query;
-      return { statusCode: 200, headers, body: JSON.stringify(gt) };
+      const arr = Array.isArray(gt?.data) ? gt.data : [];
+      const results: SearchResult[] = arr.map((d: any) => {
+        const attr = d.attributes || {};
+        const token = attr.base_token || attr.token || {};
+        return {
+          chain: attr.network || chain || 'unknown',
+          token: {
+            address: token.address,
+            symbol: token.symbol,
+            name: token.name,
+            icon: token.image_url || undefined,
+          },
+          core: {
+            priceUsd:
+              attr.base_token_price_usd !== undefined
+                ? Number(attr.base_token_price_usd)
+                : attr.price_usd !== undefined
+                ? Number(attr.price_usd)
+                : undefined,
+            liqUsd:
+              attr.liquidity_usd !== undefined ? Number(attr.liquidity_usd) : undefined,
+            vol24hUsd:
+              attr.volume_24h_usd !== undefined ? Number(attr.volume_24h_usd) : undefined,
+            priceChange1hPct:
+              attr.price_change_percentage?.h1 !== undefined
+                ? Number(attr.price_change_percentage.h1)
+                : undefined,
+            priceChange24hPct:
+              attr.price_change_percentage?.h24 !== undefined
+                ? Number(attr.price_change_percentage.h24)
+                : undefined,
+          },
+          pools: [
+            {
+              pairId: d.id,
+              dex: attr.dex || attr.name || '',
+              base: attr.base_token?.symbol,
+              quote: attr.quote_token?.symbol,
+              chain: attr.network || chain || 'unknown',
+              poolAddress: attr.pool_address || d.id,
+            },
+          ],
+          provider: 'gt',
+        };
+      });
+      log('gt results', results.length);
+      const bodyRes: SearchResponse = { query, results };
+      if (!results.length) throw new Error('empty');
+      return { statusCode: 200, headers, body: JSON.stringify(bodyRes) };
     } catch {
       if (CG_API_BASE && CG_API_KEY && isValidChain(chain)) {
         try {

--- a/netlify/functions/token.ts
+++ b/netlify/functions/token.ts
@@ -4,6 +4,11 @@ import type { TokenResponse, ApiError } from '../../src/lib/types';
 const CG_API_BASE = process.env.COINGECKO_API_BASE || '';
 const CG_API_KEY = process.env.COINGECKO_API_KEY || '';
 const DS_API_BASE = process.env.DS_API_BASE || '';
+const DEBUG = process.env.DEBUG_LOGS === 'true';
+
+function log(...args: any[]) {
+  if (DEBUG) console.log('[token]', ...args);
+}
 
 function isValidChain(chain?: string): chain is string {
   return !!chain;
@@ -51,6 +56,8 @@ export const handler: Handler = async (event) => {
   let core: any = null;
   let provider: 'cg' | 'ds' | undefined;
 
+  log('params', { chain, address });
+
   if (CG_API_BASE && CG_API_KEY) {
     try {
       const cg = await fetchCgToken(chain, address);
@@ -76,6 +83,7 @@ export const handler: Handler = async (event) => {
           priceChange?.h24 !== undefined ? Number(priceChange.h24) : undefined,
       };
       provider = 'cg';
+      log('cg token');
     } catch {
       // ignore and fall back to DS
     }
@@ -125,6 +133,7 @@ export const handler: Handler = async (event) => {
                 : undefined,
           };
           provider = 'ds';
+          log('ds token');
         }
       }
     } catch {

--- a/src/features/chart/ChartPage.tsx
+++ b/src/features/chart/ChartPage.tsx
@@ -5,6 +5,7 @@ import { pairs } from '../../lib/api';
 import PoolSwitcher from './PoolSwitcher';
 import ChartOnlyView from './ChartOnlyView';
 import DetailView from './DetailView';
+import TradesOnlyView from './TradesOnlyView';
 import copy from '../../copy/en.json';
 import chains from '../../lib/chains.json';
 
@@ -44,7 +45,11 @@ export default function ChartPage() {
       .then((data) => {
         if (cancelled) return;
         if ('error' in data) {
-          setError(data.error);
+          if (data.error === 'unsupported_network') {
+            setUnsupported(true);
+          } else {
+            setError(data.error);
+          }
           return;
         }
         setToken(data.token);
@@ -84,7 +89,7 @@ export default function ChartPage() {
       {loading && <div>{copy.loading}</div>}
 
       {unsupported && (
-        <div style={{ color: 'red' }}>This network is unsupported yet</div>
+        <div style={{ color: 'red' }}>This network is currently unsupported.</div>
       )}
 
       {!loading && error && (
@@ -119,11 +124,18 @@ export default function ChartPage() {
               />
             </div>
           )}
+          {view === 'trades' && currentPool && currentPool.poolAddress && (
+            <TradesOnlyView
+              pairId={currentPool.pairId}
+              chain={currentPool.chain}
+              poolAddress={currentPool.poolAddress}
+            />
+          )}
           {view === 'detail' && currentPool && address && (
             <DetailView chain={currentPool.chain} address={address} pairId={currentPool.pairId} />
           )}
 
-          {noData && <div>No data</div>}
+          {noData && <div>No chart data available for this pool</div>}
         </>
       )}
     </div>

--- a/src/features/chart/TradesOnlyView.tsx
+++ b/src/features/chart/TradesOnlyView.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import type { Trade } from '../../lib/types';
+import { trades } from '../../lib/api';
+
+interface Props {
+  pairId: string;
+  chain: string;
+  poolAddress?: string;
+}
+
+export default function TradesOnlyView({ pairId, chain, poolAddress }: Props) {
+  const [rows, setRows] = useState<Trade[]>([]);
+  const [noTrades, setNoTrades] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    trades({ pairId, chain, poolAddress })
+      .then((data) => {
+        if (cancelled) return;
+        setRows(data.trades || []);
+        setNoTrades(!data.trades || data.trades.length === 0);
+      })
+      .catch(() => {
+        if (!cancelled) setNoTrades(true);
+      });
+    return () => {
+        cancelled = true;
+    };
+  }, [pairId, chain, poolAddress]);
+
+  if (noTrades) {
+    return <div>No trades available in the last 24h</div>;
+  }
+
+  return (
+    <table style={{ width: '100%' }}>
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Side</th>
+          <th>Price</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((t) => (
+          <tr key={t.txHash || t.ts}>
+            <td>{new Date(t.ts * 1000).toLocaleTimeString()}</td>
+            <td>{t.side}</td>
+            <td>${t.price.toFixed(4)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- resolve true pool addresses from Dexscreener with GeckoTerminal fallback and reject unsupported networks
- surface real pool addresses in search results and leverage them for OHLC/trade GT fallbacks
- keep chart UI responsive with explicit no-data messaging and trades-only view

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dab9326748323a8f8f64fc7cd4662