### PR TITLE
feat: mobile UI polish and smoke tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.2.1",
+        "ts-node": "^10.9.2",
         "typescript": "^5.2.2",
         "vite": "^5.0.0"
       }
@@ -316,6 +317,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1044,6 +1069,34 @@
         "win32"
       ]
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1096,6 +1149,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1144,6 +1208,39 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.25.2",
@@ -1206,6 +1303,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -1229,6 +1333,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1380,6 +1494,13 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1586,6 +1707,50 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -1599,6 +1764,14 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -1635,6 +1808,13 @@
       "version": "1.6.17",
       "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.17.tgz",
       "integrity": "sha512-WHNHvDCXURn+Qwb3QUUzP6rOxx+3kUZUspREyhkqmXCxFIND99l5z9intTh+uPEt+/EEu7lCaMjSd1uTfuTXfg==",
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -1703,6 +1883,16 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5.2.2",
     "vite": "^5.0.0"
   }

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,0 +1,60 @@
+// Smoke tests for backend endpoints
+// Run: npx ts-node scripts/smoke.ts
+
+const BASE = process.env.BASE_URL || 'http://localhost:8888/.netlify/functions';
+const ADDRESS = '0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'; // USDC
+
+function u(path: string) {
+  return `${BASE}${path}`;
+}
+
+async function main() {
+  const table: { endpoint: string; provider: string | null; items: string | null }[] = [];
+
+  // search
+  const searchRes = await fetch(u(`/search?query=${ADDRESS}`));
+  const searchData = await searchRes.json();
+  const pool = searchData.results?.[0]?.pools?.find((p: any) => p.poolAddress);
+  if (!pool) throw new Error('search: no pool with poolAddress');
+  const poolAddress = pool.poolAddress as string;
+  table.push({ endpoint: 'search', provider: searchRes.headers.get('x-provider'), items: searchRes.headers.get('x-items') });
+
+  // pairs
+  const pairsRes = await fetch(u(`/pairs?chain=ethereum&address=${ADDRESS}`));
+  const pairsData = await pairsRes.json();
+  const found = pairsData.pools?.some((p: any) => p.poolAddress === poolAddress && p.gtSupported);
+  if (!found) throw new Error('pairs: poolAddress or gtSupported missing');
+  table.push({ endpoint: 'pairs', provider: pairsRes.headers.get('x-provider'), items: pairsRes.headers.get('x-items') });
+
+  const pairId = pool.pairId as string;
+
+  // ohlc
+  const ohlcRes = await fetch(u(`/ohlc?pairId=${pairId}&chain=ethereum&poolAddress=${poolAddress}&tf=1m`));
+  const ohlcData = await ohlcRes.json();
+  const eff = ohlcRes.headers.get('x-effective-tf');
+  if (!(Array.isArray(ohlcData.candles) && ohlcData.candles.length > 0) && !eff) {
+    throw new Error('ohlc: empty response');
+  }
+  table.push({ endpoint: 'ohlc', provider: ohlcRes.headers.get('x-provider'), items: ohlcRes.headers.get('x-items') });
+
+  // trades
+  const tradesRes = await fetch(u(`/trades?pairId=${pairId}&chain=ethereum&poolAddress=${poolAddress}`));
+  const tradesData = await tradesRes.json();
+  const count = Array.isArray(tradesData.trades) ? tradesData.trades.length : 0;
+  if (count < 0 || count > 300) throw new Error('trades: count out of range');
+  table.push({ endpoint: 'trades', provider: tradesRes.headers.get('x-provider'), items: tradesRes.headers.get('x-items') });
+
+  // token
+  const tokenRes = await fetch(u(`/token?chain=ethereum&address=${ADDRESS}`));
+  const tokenData = await tokenRes.json();
+  const links = tokenData.links ? Object.values(tokenData.links).filter(Boolean) : [];
+  if (links.length < 1) throw new Error('token: no links');
+  table.push({ endpoint: 'token', provider: tokenRes.headers.get('x-provider'), items: tokenRes.headers.get('x-items') });
+
+  console.table(table);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/features/chart/ChartOnlyView.tsx
+++ b/src/features/chart/ChartOnlyView.tsx
@@ -1,22 +1,50 @@
 import { useState, useEffect } from 'react';
-import type { Timeframe } from '../../lib/types';
+import type { Timeframe, Provider } from '../../lib/types';
 import PriceChart from './PriceChart';
 import { getTradeMarkers, type TradeMarkerCluster } from '../trades/TradeMarkers';
+import { ohlc } from '../../lib/api';
+import { getCachedTf, setCachedTf } from '../../lib/tf-cache';
 
 interface Props {
   pairId: string;
   chain: string;
   poolAddress?: string;
   address: string;
-  tf: Timeframe;
+  provider: Provider;
   xDomain: [number, number] | null;
   onXDomainChange?: (d: [number, number]) => void;
 }
 
-export default function ChartOnlyView({ pairId, chain, poolAddress, address, tf, xDomain, onXDomainChange }: Props) {
+export default function ChartOnlyView({ pairId, chain, poolAddress, address, provider, xDomain, onXDomainChange }: Props) {
   const [showMarkers, setShowMarkers] = useState(false);
   const [markers, setMarkers] = useState<TradeMarkerCluster[]>([]);
   const [noTrades, setNoTrades] = useState(false);
+  const [tf, setTf] = useState<Timeframe | null>(null);
+
+  useEffect(() => {
+    const cached = getCachedTf(pairId, provider);
+    if (cached) {
+      setTf(cached);
+      return;
+    }
+    const order: Timeframe[] =
+      provider === 'cg' ? ['1m', '5m'] : provider === 'gt' ? ['5m', '15m', '1h'] : ['1m'];
+    (async () => {
+      for (const t of order) {
+        try {
+          const res = await ohlc({ pairId, chain, poolAddress, tf: t, address });
+          if (res.candles.length > 0 || res.effectiveTf) {
+            const eff = res.effectiveTf || t;
+            setTf(eff);
+            setCachedTf(pairId, provider, eff);
+            break;
+          }
+        } catch {
+          /* ignore and try next */
+        }
+      }
+    })();
+  }, [pairId, provider, chain, poolAddress, address]);
 
   useEffect(() => {
     if (showMarkers) {
@@ -36,6 +64,10 @@ export default function ChartOnlyView({ pairId, chain, poolAddress, address, tf,
       }
       return next;
     });
+  }
+
+  if (!tf) {
+    return <div>Loading…</div>;
   }
 
   return (

--- a/src/features/chart/ChartPage.tsx
+++ b/src/features/chart/ChartPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import type { PoolSummary, TokenMeta } from '../../lib/types';
+import type { PoolSummary, TokenMeta, Provider } from '../../lib/types';
 import { pairs } from '../../lib/api';
 import PoolSwitcher from './PoolSwitcher';
 import ChartOnlyView from './ChartOnlyView';
@@ -17,6 +17,7 @@ export default function ChartPage() {
   const [token, setToken] = useState<TokenMeta | null>(null);
   const [pools, setPools] = useState<PoolSummary[]>([]);
   const [currentPool, setCurrentPool] = useState<PoolSummary | null>(null);
+  const [provider, setProvider] = useState<Provider | null>(null);
   const [searchParams] = useSearchParams();
   const view = (searchParams.get('view') as View) || 'chart';
   const [xDomain, setXDomain] = useState<[number, number] | null>(null);
@@ -34,6 +35,7 @@ export default function ChartPage() {
     setUnsupported(false);
     setLoading(true);
     setError(null);
+    setProvider(null);
     pairs(chain, address)
       .then((data) => {
         if (cancelled) return;
@@ -47,6 +49,7 @@ export default function ChartPage() {
           return;
         }
         setToken(data.token);
+        setProvider(data.provider);
         const sorted = data.pools.slice().sort((a, b) => {
           const sup = Number(!!b.gtSupported) - Number(!!a.gtSupported);
           if (sup !== 0) return sup;
@@ -112,14 +115,14 @@ export default function ChartPage() {
             />
           )}
 
-          {view === 'chart' && currentPool && currentPool.poolAddress && (
+          {view === 'chart' && currentPool && currentPool.poolAddress && provider && (
             <div style={{ marginTop: '1rem' }}>
               <ChartOnlyView
                 pairId={currentPool.pairId}
                 chain={currentPool.chain}
                 poolAddress={currentPool.poolAddress}
                 address={address!}
-                tf="1m"
+                provider={provider}
                 xDomain={xDomain}
                 onXDomainChange={setXDomain}
               />

--- a/src/features/chart/DetailView.tsx
+++ b/src/features/chart/DetailView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { PoolSummary, TokenResponse } from '../../lib/types';
 import { token as fetchToken } from '../../lib/api';
+import { formatCompact } from '../../lib/format';
 
 interface Props {
   chain: string;
@@ -63,19 +64,19 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
           <div style={{ fontSize: '0.75rem', color: '#666' }}>FDV/MC</div>
           <div>
             {kpis.fdvUsd !== undefined
-              ? `$${kpis.fdvUsd.toLocaleString()}`
+              ? `$${formatCompact(kpis.fdvUsd)}`
               : kpis.mcUsd !== undefined
-              ? `$${kpis.mcUsd.toLocaleString()}`
+              ? `$${formatCompact(kpis.mcUsd)}`
               : '-'}
           </div>
         </div>
         <div>
           <div style={{ fontSize: '0.75rem', color: '#666' }}>Liquidity</div>
-          <div>{kpis.liqUsd !== undefined ? `$${kpis.liqUsd.toLocaleString()}` : '-'}</div>
+          <div>{kpis.liqUsd !== undefined ? `$${formatCompact(kpis.liqUsd)}` : '-'}</div>
         </div>
         <div>
           <div style={{ fontSize: '0.75rem', color: '#666' }}>24h Vol</div>
-          <div>{kpis.vol24hUsd !== undefined ? `$${kpis.vol24hUsd.toLocaleString()}` : '-'}</div>
+          <div>{kpis.vol24hUsd !== undefined ? `$${formatCompact(kpis.vol24hUsd)}` : '-'}</div>
         </div>
         <div>
           <div style={{ fontSize: '0.75rem', color: '#666' }}>24h Change</div>

--- a/src/features/chart/PoolSwitcher.tsx
+++ b/src/features/chart/PoolSwitcher.tsx
@@ -1,4 +1,5 @@
 import type { PoolSummary } from '../../lib/types';
+import { formatCompact } from '../../lib/format';
 
 interface Props {
   pools: PoolSummary[];
@@ -33,11 +34,7 @@ export default function PoolSwitcher({ pools, current, onSwitch }: Props) {
             {pools.map((p) => (
               <option key={p.pairId} value={p.pairId}>
                 {`${p.dex}${p.version ? ` (${p.version})` : ''} — ${p.base}/${p.quote}${
-                  p.liqUsd
-                    ? ` — $${p.liqUsd.toLocaleString(undefined, {
-                        maximumFractionDigits: 0,
-                      })}`
-                    : ''
+                  p.liqUsd ? ` — $${formatCompact(p.liqUsd)}` : ''
                 }`}
               </option>
             ))}
@@ -58,6 +55,7 @@ export default function PoolSwitcher({ pools, current, onSwitch }: Props) {
             borderRadius: '9999px',
             border: '1px solid #999',
             background: current === p.pairId ? '#ddd' : 'transparent',
+            minHeight: 40,
           }}
         >
           {p.dex} {p.base}/{p.quote}

--- a/src/features/chart/TradesOnlyView.tsx
+++ b/src/features/chart/TradesOnlyView.tsx
@@ -34,9 +34,9 @@ export default function TradesOnlyView({ pairId, chain, poolAddress, address }: 
       {rows.length > 0 && <div>{rows.length} trades</div>}
       {rows.length === 0 && noTrades && <div>No recent trades</div>}
       {rows.length > 0 && (
-        <table style={{ width: '100%' }}>
+        <table className="search-results-table">
           <thead>
-            <tr>
+            <tr style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))' }}>
               <th>Time</th>
               <th>Side</th>
               <th>Price</th>
@@ -44,7 +44,14 @@ export default function TradesOnlyView({ pairId, chain, poolAddress, address }: 
           </thead>
           <tbody>
             {rows.map((t) => (
-              <tr key={t.txHash || t.ts}>
+              <tr
+                key={t.txHash || t.ts}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+                  minHeight: 40,
+                }}
+              >
                 <td>{new Date(t.ts * 1000).toLocaleTimeString()}</td>
                 <td>{t.side}</td>
                 <td>${t.price.toFixed(4)}</td>

--- a/src/features/lists/ListItem.tsx
+++ b/src/features/lists/ListItem.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import type { ListItem as Item } from '../../lib/types';
+import { formatCompact } from '../../lib/format';
 
 interface Props {
   item: Item;
@@ -26,28 +27,47 @@ export default function ListItem({ item, rank }: Props) {
     ? Math.floor((Date.now() / 1000 - item.createdAt) / 86400)
     : undefined;
   return (
-      <div
-        onClick={handleClick}
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '40px 1fr 60px 80px 80px 80px 80px',
-          gap: '0.5rem',
-          padding: '0.5rem',
-          cursor: 'pointer',
-          borderBottom: '1px solid #eee',
-          background: item.promoted ? '#fffbe6' : undefined,
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') handleClick();
+      }}
+      className="list-item-row"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(7, minmax(0, 1fr))',
+        gap: '0.5rem',
+        padding: '0.5rem',
+        cursor: 'pointer',
+        borderBottom: '1px solid #eee',
+        background: item.promoted ? '#fffbe6' : undefined,
+        minHeight: 40,
       }}
     >
       <div>{rank}</div>
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <strong>{item.token.symbol}</strong>
-        <span style={{ fontSize: '0.75rem', color: '#666' }}>{pair}</span>
+      <div style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        <strong style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.token.symbol}</strong>
+        <span style={{ fontSize: '0.75rem', color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {pair}
+        </span>
       </div>
-      <div>{ageDays !== undefined ? `${ageDays}d` : '-'}</div>
-      <div>{item.priceUsd !== undefined ? `$${item.priceUsd.toFixed(4)}` : '-'}</div>
-      <div>{item.liqUsd !== undefined ? `$${item.liqUsd.toLocaleString()}` : '-'}</div>
-      <div>{item.volWindowUsd !== undefined ? `$${item.volWindowUsd.toLocaleString()}` : '-'}</div>
-      <div>{item.priceChangePct !== undefined ? `${item.priceChangePct.toFixed(2)}%` : '-'}</div>
+      <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {ageDays !== undefined ? `${ageDays}d` : '-'}
+      </div>
+      <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {item.priceUsd !== undefined ? `$${item.priceUsd.toFixed(4)}` : '-'}
+      </div>
+      <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {formatCompact(item.liqUsd)}
+      </div>
+      <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {formatCompact(item.volWindowUsd)}
+      </div>
+      <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {item.priceChangePct !== undefined ? `${item.priceChangePct.toFixed(2)}%` : '-'}
+      </div>
     </div>
   );
 }
@@ -57,10 +77,11 @@ export function ListItemSkeleton() {
     <div
       style={{
         display: 'grid',
-        gridTemplateColumns: '40px 1fr 60px 80px 80px 80px 80px',
+        gridTemplateColumns: 'repeat(7, minmax(0, 1fr))',
         gap: '0.5rem',
         padding: '0.5rem',
         borderBottom: '1px solid #eee',
+        minHeight: 40,
       }}
     >
       {Array.from({ length: 7 }).map((_, i) => (

--- a/src/features/search/SearchPage.tsx
+++ b/src/features/search/SearchPage.tsx
@@ -126,17 +126,8 @@ export default function SearchPage() {
       )}
       {(loading || results.length > 0) && (
         <table className="search-results-table">
-          <colgroup>
-            <col style={{ width: '40px' }} />
-            <col />
-            <col style={{ width: '80px' }} />
-            <col style={{ width: '80px' }} />
-            <col style={{ width: '80px' }} />
-            <col style={{ width: '80px' }} />
-            <col style={{ width: '80px' }} />
-          </colgroup>
           <thead>
-            <tr>
+            <tr style={{ display: 'grid', gridTemplateColumns: 'repeat(7, minmax(0, 1fr))' }}>
               <th></th>
               <th>Token</th>
               <th>Chain</th>

--- a/src/features/search/SearchResultItem.tsx
+++ b/src/features/search/SearchResultItem.tsx
@@ -1,18 +1,20 @@
 import { useNavigate } from 'react-router-dom';
 import type { SearchResult } from '../../lib/types';
+import { formatCompact } from '../../lib/format';
 
 interface Props { result: SearchResult }
 
 export function SearchResultSkeleton() {
   return (
-    <tr>
-      <td><div style={{ width: 24, height: 24, background: '#eee', borderRadius: 4 }} /></td>
-      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
-      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
-      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
-      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
-      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
-      <td><div style={{ height: 16, background: '#eee', borderRadius: 4 }} /></td>
+    <tr style={{ display: 'grid', gridTemplateColumns: 'repeat(7, minmax(0, 1fr))', minHeight: 40 }}>
+      <td>
+        <div style={{ width: 24, height: 24, background: '#eee', borderRadius: 4 }} />
+      </td>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <td key={i}>
+          <div style={{ height: 16, background: '#eee', borderRadius: 4 }} />
+        </td>
+      ))}
     </tr>
   );
 }
@@ -29,8 +31,15 @@ export default function SearchResultItem({ result }: Props) {
       role="button"
       tabIndex={0}
       onClick={handleClick}
-      onKeyDown={(e) => { if (e.key === 'Enter') handleClick(); }}
-      style={{ cursor: 'pointer' }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') handleClick();
+      }}
+      style={{
+        cursor: 'pointer',
+        display: 'grid',
+        gridTemplateColumns: 'repeat(7, minmax(0, 1fr))',
+        minHeight: 40,
+      }}
     >
       <td>
         {token.icon ? (
@@ -40,16 +49,28 @@ export default function SearchResultItem({ result }: Props) {
         )}
       </td>
       <td>
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
-          <strong>{token.symbol}</strong>
-          <span style={{ fontSize: '0.75rem', color: '#666' }}>{token.name}</span>
+        <div style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          <strong style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{token.symbol}</strong>
+          <span style={{ fontSize: '0.75rem', color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {token.name}
+          </span>
         </div>
       </td>
-      <td style={{ fontSize: '0.875rem', color: '#666' }}>{chain}</td>
-      <td>{core.priceUsd !== undefined ? `$${core.priceUsd.toFixed(4)}` : '-'}</td>
-      <td>{core.liqUsd !== undefined ? `$${core.liqUsd.toLocaleString()}` : '-'}</td>
-      <td>{core.vol24hUsd !== undefined ? `$${core.vol24hUsd.toLocaleString()}` : '-'}</td>
-      <td>{core.priceChange24hPct !== undefined ? `${core.priceChange24hPct.toFixed(2)}%` : '-'}</td>
+      <td style={{ fontSize: '0.875rem', color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {chain}
+      </td>
+      <td style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {core.priceUsd !== undefined ? `$${core.priceUsd.toFixed(4)}` : '-'}
+      </td>
+      <td style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {formatCompact(core.liqUsd)}
+      </td>
+      <td style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {formatCompact(core.vol24hUsd)}
+      </td>
+      <td style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {core.priceChange24hPct !== undefined ? `${core.priceChange24hPct.toFixed(2)}%` : '-'}
+      </td>
     </tr>
   );
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,9 @@
+const formatter = new Intl.NumberFormat(undefined, {
+  notation: 'compact',
+  maximumFractionDigits: 2,
+});
+
+export function formatCompact(value?: number): string {
+  if (value === undefined || value === null || isNaN(value)) return '-';
+  return formatter.format(value);
+}

--- a/src/lib/tf-cache.ts
+++ b/src/lib/tf-cache.ts
@@ -1,0 +1,35 @@
+import type { Timeframe, Provider } from './types';
+
+const CACHE_KEY = 'tf-cache';
+
+function getStore(): Record<string, Timeframe> {
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, Timeframe>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function setStore(store: Record<string, Timeframe>) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(store));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function getCachedTf(pairId: string, provider: Provider): Timeframe | undefined {
+  const key = `${pairId}:${provider}`;
+  const store = getStore();
+  return store[key];
+}
+
+export function setCachedTf(pairId: string, provider: Provider, tf: Timeframe) {
+  const key = `${pairId}:${provider}`;
+  const store = getStore();
+  store[key] = tf;
+  setStore(store);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -77,7 +77,7 @@ main {
 }
 
 main.with-tabs {
-  padding-bottom: 56px;
+  padding-bottom: calc(56px + env(safe-area-inset-bottom));
 }
 
 .bottom-tabs {
@@ -88,7 +88,8 @@ main.with-tabs {
   display: flex;
   background: var(--color-bg-muted);
   border-top: 1px solid var(--color-surface);
-  height: 56px;
+  height: calc(56px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .bottom-tabs a {
@@ -106,6 +107,11 @@ main.with-tabs {
 }
 
 .bottom-tabs a:focus-visible {
+  outline: 2px solid var(--color-accent);
+}
+
+.list-item-row:focus-visible,
+.search-results-table tr:focus-visible {
   outline: 2px solid var(--color-accent);
 }
 
@@ -136,6 +142,14 @@ button:focus-visible {
   width: 100%;
   border-collapse: collapse;
   margin-top: 0.5rem;
+  table-layout: fixed;
+}
+
+.search-results-table th,
+.search-results-table td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .search-results-table th,


### PR DESCRIPTION
## Summary
- keep bottom tabs above iOS Safari toolbar using safe-area inset
- format large numbers with compact notation and responsive grid tables
- cache working timeframes per provider and add smoke test script

## Testing
- `npm test` (fails: Missing script)
- `npx ts-node scripts/smoke.ts` (fails: fetch failed)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dcd7828648323875e1be2aa68cd20