### PR TITLE
feat: enhance detail view and observability

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -14,8 +14,8 @@ async function main() {
   // search
   const searchRes = await fetch(u(`/search?query=${ADDRESS}`));
   const searchData = await searchRes.json();
-  const pool = searchData.results?.[0]?.pools?.find((p: any) => p.poolAddress);
-  if (!pool) throw new Error('search: no pool with poolAddress');
+  const pool = searchData.results?.[0]?.pools?.find((p: any) => p.poolAddress && p.gtSupported);
+  if (!pool) throw new Error('search: no supported pool with poolAddress');
   const poolAddress = pool.poolAddress as string;
   table.push({ endpoint: 'search', provider: searchRes.headers.get('x-provider'), items: searchRes.headers.get('x-items') });
 
@@ -24,9 +24,13 @@ async function main() {
   const pairsData = await pairsRes.json();
   const found = pairsData.pools?.some((p: any) => p.poolAddress === poolAddress && p.gtSupported);
   if (!found) throw new Error('pairs: poolAddress or gtSupported missing');
+  const unsupported = pairsData.pools?.find((p: any) => p.poolAddress && p.gtSupported === false);
+  if (!unsupported) throw new Error('pairs: no gtUnsupported pool found');
   table.push({ endpoint: 'pairs', provider: pairsRes.headers.get('x-provider'), items: pairsRes.headers.get('x-items') });
 
   const pairId = pool.pairId as string;
+  const pairIdU = unsupported.pairId as string;
+  const poolAddressU = unsupported.poolAddress as string;
 
   // ohlc
   const ohlcRes = await fetch(u(`/ohlc?pairId=${pairId}&chain=ethereum&poolAddress=${poolAddress}&tf=1m`));
@@ -50,6 +54,24 @@ async function main() {
   const links = tokenData.links ? Object.values(tokenData.links).filter(Boolean) : [];
   if (links.length < 1) throw new Error('token: no links');
   table.push({ endpoint: 'token', provider: tokenRes.headers.get('x-provider'), items: tokenRes.headers.get('x-items') });
+
+  // unsupported pool checks
+  const ohlcResU = await fetch(u(`/ohlc?pairId=${pairIdU}&chain=ethereum&poolAddress=${poolAddressU}&tf=1m`));
+  const ohlcDataU = await ohlcResU.json();
+  if (ohlcDataU.provider === 'none') throw new Error('ohlc unsupported: provider none');
+  if (
+    ohlcDataU.provider !== 'synthetic' &&
+    !(Array.isArray(ohlcDataU.candles) && ohlcDataU.candles.length > 0 && ohlcDataU.provider === 'cg')
+  ) {
+    throw new Error('ohlc unsupported: missing cg candles');
+  }
+  const tradesResU = await fetch(u(`/trades?pairId=${pairIdU}&chain=ethereum&poolAddress=${poolAddressU}`));
+  const tradesDataU = await tradesResU.json();
+  const triedU = tradesResU.headers.get('x-fallbacks-tried') || '';
+  const countU = Array.isArray(tradesDataU.trades) ? tradesDataU.trades.length : 0;
+  if (countU === 0 && !triedU.includes('cg')) {
+    throw new Error('trades unsupported: no cg fallback');
+  }
 
   console.table(table);
 }

--- a/src/features/chart/DetailView.tsx
+++ b/src/features/chart/DetailView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { PoolSummary, TokenResponse } from '../../lib/types';
 import { token as fetchToken } from '../../lib/api';
-import { formatCompact } from '../../lib/format';
+import { formatCompact, formatAge } from '../../lib/format';
 
 interface Props {
   chain: string;
@@ -32,6 +32,7 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
   }
 
   const { meta, kpis, links, provider } = detail;
+  const createdTs = kpis.ageDays !== undefined ? Math.floor(Date.now() / 1000 - kpis.ageDays * 86400) : undefined;
 
   return (
     <div style={{ fontSize: '0.875rem' }}>
@@ -61,14 +62,12 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
           <div>{kpis.priceUsd !== undefined ? `$${kpis.priceUsd.toFixed(4)}` : '-'}</div>
         </div>
         <div>
-          <div style={{ fontSize: '0.75rem', color: '#666' }}>FDV/MC</div>
-          <div>
-            {kpis.fdvUsd !== undefined
-              ? `$${formatCompact(kpis.fdvUsd)}`
-              : kpis.mcUsd !== undefined
-              ? `$${formatCompact(kpis.mcUsd)}`
-              : '-'}
-          </div>
+          <div style={{ fontSize: '0.75rem', color: '#666' }}>FDV</div>
+          <div>{kpis.fdvUsd !== undefined ? `$${formatCompact(kpis.fdvUsd)}` : '-'}</div>
+        </div>
+        <div>
+          <div style={{ fontSize: '0.75rem', color: '#666' }}>MC</div>
+          <div>{kpis.mcUsd !== undefined ? `$${formatCompact(kpis.mcUsd)}` : '-'}</div>
         </div>
         <div>
           <div style={{ fontSize: '0.75rem', color: '#666' }}>Liquidity</div>
@@ -84,7 +83,7 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
         </div>
         <div>
           <div style={{ fontSize: '0.75rem', color: '#666' }}>Age</div>
-          <div>{kpis.ageDays !== undefined ? `${Math.floor(kpis.ageDays)}` : '-'}</div>
+          <div>{createdTs ? formatAge(createdTs) : '-'}</div>
         </div>
       </div>
       <div style={{ marginTop: '0.5rem', display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
@@ -111,6 +110,7 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
       </div>
       {pools.length > 1 && (
         <div style={{ marginTop: '0.5rem' }}>
+          <div style={{ fontSize: '0.75rem', marginBottom: '0.25rem' }}>Pools</div>
           {pools.map((p) => (
             <div key={p.pairId} style={{ marginBottom: '0.25rem' }}>
               <button
@@ -118,7 +118,9 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
                 disabled={p.pairId === pairId}
                 style={{ fontSize: '0.75rem' }}
               >
-                {p.dex} {p.base}/{p.quote}
+                {`${p.dex}${p.version ? ` (${p.version})` : ''} — ${p.base}/${p.quote}${
+                  p.liqUsd ? ` — $${formatCompact(p.liqUsd)}` : ''
+                }`}
               </button>
             </div>
           ))}

--- a/src/features/chart/PoolSwitcher.tsx
+++ b/src/features/chart/PoolSwitcher.tsx
@@ -1,5 +1,6 @@
 import type { PoolSummary } from '../../lib/types';
 import { formatCompact } from '../../lib/format';
+import { useState } from 'react';
 
 interface Props {
   pools: PoolSummary[];
@@ -8,9 +9,18 @@ interface Props {
 }
 
 export default function PoolSwitcher({ pools, current, onSwitch }: Props) {
+  const [filter, setFilter] = useState('');
   if (!pools || pools.length === 0) return null;
 
   if (pools.length > 3) {
+    const lower = filter.toLowerCase();
+    let filtered = pools.filter((p) =>
+      `${p.dex} ${p.version || ''} ${p.base}/${p.quote}`.toLowerCase().includes(lower),
+    );
+    if (current && !filtered.some((p) => p.pairId === current)) {
+      const cur = pools.find((p) => p.pairId === current);
+      if (cur) filtered = [cur, ...filtered];
+    }
     return (
       <div
         style={{
@@ -23,6 +33,14 @@ export default function PoolSwitcher({ pools, current, onSwitch }: Props) {
       >
         <label style={{ display: 'flex', flexDirection: 'column', fontSize: '0.875rem' }}>
           Pools
+          {pools.length > 10 && (
+            <input
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter"
+              style={{ padding: '0.25rem', marginTop: '0.25rem' }}
+            />
+          )}
           <select
             value={current}
             onChange={(e) => {
@@ -31,7 +49,7 @@ export default function PoolSwitcher({ pools, current, onSwitch }: Props) {
             }}
             style={{ padding: '0.25rem', marginTop: '0.25rem' }}
           >
-            {pools.map((p) => (
+            {filtered.map((p) => (
               <option key={p.pairId} value={p.pairId}>
                 {`${p.dex}${p.version ? ` (${p.version})` : ''} — ${p.base}/${p.quote}${
                   p.liqUsd ? ` — $${formatCompact(p.liqUsd)}` : ''

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,8 +22,17 @@ import {
   getTokenCache,
   setTokenCache,
 } from './cache';
+import type { FetchMeta } from './format';
 
 const BASE = '/.netlify/functions';
+
+function readMeta(res: Response): FetchMeta {
+  return {
+    tried: res.headers.get('x-fallbacks-tried'),
+    effectiveTf: res.headers.get('x-effective-tf'),
+    remapped: res.headers.get('x-remapped-pool'),
+  };
+}
 
 export async function search(query: string, provider?: string): Promise<SearchResponse | ApiError> {
   const cached = getSearchCache(query);
@@ -35,9 +44,7 @@ export async function search(query: string, provider?: string): Promise<SearchRe
   try {
     const res = await fetch(url.toString());
     const data = await res.json();
-    if (!res.ok || (data.error && data.error !== 'rate_limit')) {
-      console.log('headers', Object.fromEntries(res.headers.entries()));
-    }
+    (data as any)._meta = readMeta(res);
     if (!res.ok) {
       if (res.status === 429) {
         return { error: 'rate_limit', provider: 'none' };
@@ -67,9 +74,7 @@ export async function pairs(
 
   const res = await fetch(url.toString());
   const data = await res.json();
-  if (!res.ok || (data.error && data.error !== 'rate_limit')) {
-    console.log('headers', Object.fromEntries(res.headers.entries()));
-  }
+  (data as any)._meta = readMeta(res);
   if (res.ok) setPairsCache(key, data);
   return data;
 }
@@ -97,9 +102,7 @@ export async function ohlc(params: {
 
   const res = await fetch(url.toString());
   const data = await res.json();
-  if (!res.ok || (data as any).error) {
-    console.log('headers', Object.fromEntries(res.headers.entries()));
-  }
+  (data as any)._meta = readMeta(res);
   if (!res.ok) {
     const err: any = new Error('api error');
     err.status = res.status;
@@ -137,9 +140,7 @@ export async function trades(params: {
 
   const res = await fetch(url.toString());
   const data = await res.json();
-  if (!res.ok || (data as any).error) {
-    console.log('headers', Object.fromEntries(res.headers.entries()));
-  }
+  (data as any)._meta = readMeta(res);
   if (!res.ok) {
     const err: any = new Error('api error');
     err.status = res.status;
@@ -167,9 +168,7 @@ export async function token(
   try {
     const res = await fetch(url.toString());
     const data = await res.json();
-    if (!res.ok || (data.error && data.error !== 'rate_limit')) {
-      console.log('headers', Object.fromEntries(res.headers.entries()));
-    }
+    (data as any)._meta = readMeta(res);
     if (!res.ok) {
       return data.error ? data : { error: 'upstream_error', provider: 'none' };
     }
@@ -191,9 +190,7 @@ export async function lists(
   try {
     const res = await fetch(url.toString());
     const data = await res.json();
-    if (!res.ok || (data.error && data.error !== 'rate_limit')) {
-      console.log('headers', Object.fromEntries(res.headers.entries()));
-    }
+    (data as any)._meta = readMeta(res);
     if (!res.ok) {
       return data.error ? data : { error: 'upstream_error', provider: 'none' };
     }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -7,3 +7,38 @@ export function formatCompact(value?: number): string {
   if (value === undefined || value === null || isNaN(value)) return '-';
   return formatter.format(value);
 }
+
+export function formatAge(createdTs?: number): string {
+  if (!createdTs) return '-';
+  const now = Math.floor(Date.now() / 1000);
+  let diff = now - createdTs;
+  if (diff < 0) diff = 0;
+  const days = Math.floor(diff / 86400);
+  const hours = Math.floor((diff % 86400) / 3600);
+  const minutes = Math.floor((diff % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  return `${hours}h ${minutes}m`;
+}
+
+export interface FetchMeta {
+  tried?: string | null;
+  effectiveTf?: string | null;
+  remapped?: string | null;
+}
+
+export function formatFetchMeta(meta?: FetchMeta): string | undefined {
+  if (!meta) return undefined;
+  const parts: string[] = [];
+  const tried = meta.tried?.split(',').filter(Boolean);
+  if (tried && tried.length > 0) {
+    parts.push(`Tried: ${tried.join(' → ')}`);
+  }
+  const extras: string[] = [];
+  if (meta.effectiveTf) extras.push(`effective TF: ${meta.effectiveTf}`);
+  if (meta.remapped && meta.remapped !== '0') extras.push('remapped: yes');
+  if (extras.length > 0) {
+    parts.push(`(${extras.join('; ')})`);
+  }
+  return parts.join(' ');
+}
+


### PR DESCRIPTION
## Summary
- show token icons, KPIs, links and pools with human-readable age in detail view
- add pool search and compact stats in pool switcher
- surface server fallback headers and add unsupported pool smoke test

## Testing
- `npm run build`
- `npx ts-node scripts/smoke.ts` *(fails: fetch failed ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_689dd574acd083239755c47c952e0339