### PR TITLE
feat: map chains to geckoterminal networks

### DIFF
--- a/netlify/shared/chains.ts
+++ b/netlify/shared/chains.ts
@@ -1,0 +1,12 @@
+export const CHAIN_TO_GT_NETWORK: Record<string, string> = {
+  ethereum: 'eth',
+  arbitrum: 'arb',
+  base: 'base',
+  bsc: 'bsc',
+  polygon: 'pos', // Polygon PoS
+  avalanche: 'avax',
+  optimism: 'op',
+  fantom: 'ftm',
+  // add more as needed
+};
+export const SUPPORTED_GT_NETWORKS = new Set(Object.values(CHAIN_TO_GT_NETWORK));

--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -1,0 +1,21 @@
+export const CHAIN_TO_GT_NETWORK = {
+  ethereum: 'eth',
+  arbitrum: 'arb',
+  base: 'base',
+  bsc: 'bsc',
+  polygon: 'pos', // Polygon PoS
+  avalanche: 'avax',
+  optimism: 'op',
+  fantom: 'ftm',
+  // add more as needed
+} as const;
+
+export type GTNetwork = typeof CHAIN_TO_GT_NETWORK[keyof typeof CHAIN_TO_GT_NETWORK];
+
+export const SUPPORTED_GT_NETWORKS = new Set<GTNetwork>(
+  Object.values(CHAIN_TO_GT_NETWORK)
+);
+
+export function toGTNetwork(chain: string): GTNetwork | null {
+  return (CHAIN_TO_GT_NETWORK as Record<string, GTNetwork>)[chain] ?? null;
+}


### PR DESCRIPTION
## Summary
- add chain-to-network mapping for GeckoTerminal in server and client
- expose helper to translate chain slugs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689df221da488323ab137a5062001aed