### PR TITLE
feat: synthesize candles from trades

### DIFF
--- a/netlify/functions/ohlc.ts
+++ b/netlify/functions/ohlc.ts
@@ -58,6 +58,15 @@ const TF_FALLBACK_CG: Record<Timeframe, Timeframe[]> = {
   '1d': ['1d'],
 };
 
+const TF_TO_SEC: Record<Timeframe, number> = {
+  '1m': 60,
+  '5m': 300,
+  '15m': 900,
+  '1h': 3600,
+  '4h': 14400,
+  '1d': 86400,
+};
+
 
 function mapTfToCG(tf: Timeframe): string {
   const map: Record<Timeframe, string> = {
@@ -294,7 +303,8 @@ export const handler: Handler = async (event) => {
     }
 
     if (trades.length > 0) {
-      candles = buildCandlesFromTrades(trades, tf);
+      const tfSec = TF_TO_SEC[tf] || 60;
+      candles = buildCandlesFromTrades(trades, tfSec);
       provider = 'synthetic';
       effectiveTf = tf;
       headers['x-provider'] = 'synthetic';

--- a/netlify/shared/agg.ts
+++ b/netlify/shared/agg.ts
@@ -1,4 +1,4 @@
-import type { Candle, Trade, Timeframe } from '../../src/lib/types';
+import type { Candle, Trade } from '../../src/lib/types';
 
 /**
  * Aggregate trades into OHLC candles.
@@ -6,19 +6,13 @@ import type { Candle, Trade, Timeframe } from '../../src/lib/types';
  * Volume is summed using the trade's base amount when available. Trades
  * lacking a base amount contribute zero volume.
  */
-export function buildCandlesFromTrades(trades: Trade[], tf: Timeframe = '1m'): Candle[] {
-  const bucketSec: Record<Timeframe, number> = {
-    '1m': 60,
-    '5m': 300,
-    '15m': 900,
-    '1h': 3600,
-    '4h': 14400,
-    '1d': 86400,
-  };
-  const interval = bucketSec[tf] || 60;
+export function buildCandlesFromTrades(
+  trades: Trade[],
+  tfSeconds: number = 60
+): Candle[] {
   const buckets: Record<number, Candle> = {};
   for (const t of trades) {
-    const bucket = Math.floor(t.ts / interval) * interval;
+    const bucket = Math.floor(t.ts / tfSeconds) * tfSeconds;
     const candle = buckets[bucket];
     if (!candle) {
       buckets[bucket] = {


### PR DESCRIPTION
## Summary
- build OHLC candles from trades using explicit timeframe seconds
- synthesize candles when no OHLC data available

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689dfc03fb4c8323ba72198cb4d8fc2e