### PR TITLE
Sanitize trades before aggregation

### DIFF
--- a/netlify/shared/agg.ts
+++ b/netlify/shared/agg.ts
@@ -1,6 +1,38 @@
 import type { Candle, Trade } from '../../src/lib/types';
 
 /**
+ * Normalize a list of trades ensuring numeric fields are finite and that sides
+ * are well-formed. Invalid trades are dropped and the remainder is sorted by
+ * timestamp.
+ */
+export function sanitizeTrades(trades: Trade[]): Trade[] {
+  const clean: Trade[] = [];
+  for (const t of trades) {
+    const ts = Math.floor(Number(t.ts));
+    const price = Number(t.price);
+    const amountBase =
+      t.amountBase !== undefined ? Number(t.amountBase) : undefined;
+    const amountQuote =
+      t.amountQuote !== undefined ? Number(t.amountQuote) : undefined;
+    if (!Number.isFinite(ts) || !Number.isFinite(price)) continue;
+    if (amountBase !== undefined && !Number.isFinite(amountBase)) continue;
+    if (amountQuote !== undefined && !Number.isFinite(amountQuote)) continue;
+    const side = t.side === 'sell' ? 'sell' : 'buy';
+    clean.push({
+      ts,
+      side,
+      price,
+      amountBase,
+      amountQuote,
+      txHash: t.txHash,
+      wallet: t.wallet,
+    });
+  }
+  clean.sort((a, b) => a.ts - b.ts);
+  return clean;
+}
+
+/**
  * Aggregate trades into OHLC candles.
  *
  * Volume is summed using the trade's base amount when available. Trades
@@ -10,6 +42,7 @@ export function buildCandlesFromTrades(
   trades: Trade[],
   tfSeconds: number = 60
 ): Candle[] {
+  trades = sanitizeTrades(trades);
   const buckets: Record<number, Candle> = {};
   for (const t of trades) {
     const bucket = Math.floor(t.ts / tfSeconds) * tfSeconds;


### PR DESCRIPTION
## Summary
- add trade sanitization to drop invalid records and sort by timestamp
- normalize GT and CG trade timestamps and enforce numeric fields

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e02eef814832381e0ff9ba99f5d50