### PR TITLE
Add provider diagnostics and API guardrails

### DIFF
--- a/src/features/chart/PriceChart.tsx
+++ b/src/features/chart/PriceChart.tsx
@@ -56,6 +56,7 @@ export default function PriceChart({
   const [effectiveTf, setEffectiveTf] = useState<Timeframe | undefined>();
   const [meta, setMeta] = useState<FetchMeta | null>(null);
   const loggedRef = useRef(false);
+  const sampleCandlesLoggedRef = useRef(false);
 
   const explorerTemplate = useMemo(() => {
     if (!chain) return undefined;
@@ -173,6 +174,10 @@ export default function PriceChart({
         candleSeriesRef.current?.setData(c);
         volumeSeriesRef.current?.setData(v);
         setHasData(true);
+        if (!sampleCandlesLoggedRef.current && (import.meta as any).env?.DEV) {
+          console.log('sample candles', candles.slice(0, 2).map((cd) => ({ t: cd.t, o: cd.o, h: cd.h, l: cd.l, c: cd.c })));
+          sampleCandlesLoggedRef.current = true;
+        }
       } else {
         setHasData(false);
       }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -28,9 +28,11 @@ const BASE = '/.netlify/functions';
 
 function readMeta(res: Response): FetchMeta {
   return {
+    provider: res.headers.get('x-provider'),
     tried: res.headers.get('x-fallbacks-tried'),
     effectiveTf: res.headers.get('x-effective-tf'),
     remapped: res.headers.get('x-remapped-pool'),
+    items: res.headers.get('x-items'),
   };
 }
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -21,9 +21,11 @@ export function formatAge(createdTs?: number): string {
 }
 
 export interface FetchMeta {
+  provider?: string | null;
   tried?: string | null;
   effectiveTf?: string | null;
   remapped?: string | null;
+  items?: string | null;
 }
 
 export function formatFetchMeta(meta?: FetchMeta): string | undefined {
@@ -31,14 +33,13 @@ export function formatFetchMeta(meta?: FetchMeta): string | undefined {
   const parts: string[] = [];
   const tried = meta.tried?.split(',').filter(Boolean);
   if (tried && tried.length > 0) {
-    parts.push(`Tried: ${tried.join(' → ')}`);
+    parts.push(`Tried: ${tried.join('→')}`);
   }
   const extras: string[] = [];
-  if (meta.effectiveTf) extras.push(`effective TF: ${meta.effectiveTf}`);
-  if (meta.remapped && meta.remapped !== '0') extras.push('remapped: yes');
-  if (extras.length > 0) {
-    parts.push(`(${extras.join('; ')})`);
-  }
+  if (meta.effectiveTf) extras.push(`tf: ${meta.effectiveTf}`);
+  if (meta.items) extras.push(`items: ${meta.items}`);
+  if (meta.remapped) extras.push(`remap: ${meta.remapped !== '0' ? 'yes' : 'no'}`);
+  if (extras.length > 0) parts.push(`(${extras.join(', ')})`);
   return parts.join(' ');
 }
 


### PR DESCRIPTION
## Summary
- Surface provider diagnostics by capturing response headers and formatting captions
- Log sample candles in debug builds for easier chart data debugging
- Validate GT network and pool before fetch and expose CoinGecko auth status

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e055c9c3c83238bc81022d3ae5965