### PR TITLE
feat: enrich token detail with DexScreener info and pool stats

### DIFF
--- a/src/features/chart/DetailView.tsx
+++ b/src/features/chart/DetailView.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import type { PoolSummary, TokenResponse } from '../../lib/types';
+import type { PoolSummary, TokenResponse, TokenPairInfo } from '../../lib/types';
 import { token as fetchToken } from '../../lib/api';
-import { formatCompact, formatAge } from '../../lib/format';
+import { formatCompact, formatAge, formatUsd } from '../../lib/format';
+import '../../styles/detail.css';
 
 interface Props {
   chain: string;
@@ -11,8 +12,33 @@ interface Props {
   onSwitch: (p: PoolSummary) => void;
 }
 
+const LINK_ICONS: Record<string, string> = {
+  website: '🌐',
+  twitter: '🐦',
+  telegram: '📢',
+  discord: '💬',
+  github: '🐙',
+  medium: '✍️',
+  instagram: '📸',
+  facebook: '📘',
+  threads: '🧵',
+  nft: '🖼️',
+  docs: '📚',
+};
+
+const EXPLORER_ADDR: Record<string, string> = {
+  ethereum: 'https://etherscan.io/address/',
+  arbitrum: 'https://arbiscan.io/address/',
+  polygon: 'https://polygonscan.com/address/',
+  bsc: 'https://bscscan.com/address/',
+  base: 'https://basescan.org/address/',
+  optimism: 'https://optimistic.etherscan.io/address/',
+  avalanche: 'https://snowtrace.io/address/',
+};
+
 export default function DetailView({ chain, address, pairId, pools, onSwitch }: Props) {
   const [detail, setDetail] = useState<TokenResponse | null>(null);
+  const [descExpanded, setDescExpanded] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -25,104 +51,160 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
     };
   }, [chain, address]);
 
-  const currentPool = pools.find((p) => p.pairId === pairId) || null;
-
   if (!detail) {
-    return <div style={{ fontSize: '0.875rem' }}>Loading…</div>;
+    return <div className="detail">Loading…</div>;
   }
 
-  const { meta, kpis, links, provider } = detail;
-  const createdTs = kpis.ageDays !== undefined ? Math.floor(Date.now() / 1000 - kpis.ageDays * 86400) : undefined;
+  const { meta, kpis, info, provider, pairs } = detail;
+  const createdTs =
+    kpis.ageDays !== undefined ? Math.floor(Date.now() / 1000 - kpis.ageDays * 86400) : undefined;
 
-  return (
-    <div style={{ fontSize: '0.875rem' }}>
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
-        {meta.icon && (
-          <img src={meta.icon} alt="" style={{ width: 24, height: 24, marginRight: 8 }} />
-        )}
-        <div style={{ flex: 1 }}>
-          <div>
-            <strong>{meta.symbol}</strong> {meta.name}
+  const renderLinks = () => {
+    const items: { key: string; url: string }[] = [];
+    info?.websites?.forEach((w) => {
+      if (w?.url) items.push({ key: (w.label || 'website').toLowerCase(), url: w.url });
+    });
+    info?.socials?.forEach((s) => {
+      if (s?.url) items.push({ key: (s.type || '').toLowerCase(), url: s.url });
+    });
+    if (!items.length) return null;
+    return (
+      <div className="detail-links">
+        {items.map((l, i) => {
+          const icon = LINK_ICONS[l.key] || '🔗';
+          return (
+            <a
+              key={i}
+              href={l.url}
+              target="_blank"
+              rel="noreferrer nofollow"
+              aria-label={l.key}
+            >
+              {icon}
+            </a>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderPool = (p: TokenPairInfo) => {
+    const explorer = p.poolAddress ? EXPLORER_ADDR[chain]?.concat(p.poolAddress) : undefined;
+    const age = p.pairCreatedAt ? formatAge(p.pairCreatedAt) : '-';
+    const txStr = p.txns
+      ? `${p.txns.m5 ?? '-'} / ${p.txns.h1 ?? '-'} / ${p.txns.h6 ?? '-'} / ${p.txns.h24 ?? '-'}`
+      : '-';
+    const volStr = p.volume
+      ? `${formatCompact(p.volume.m5)} / ${formatCompact(p.volume.h1)} / ${formatCompact(
+          p.volume.h6
+        )} / ${formatCompact(p.volume.h24)}`
+      : '-';
+    const pcStr = p.priceChange
+      ? `${p.priceChange.m5 ?? '-'}% / ${p.priceChange.h1 ?? '-'}% / ${p.priceChange.h6 ?? '-'}% / ${
+          p.priceChange.h24 ?? '-'
+        }%`
+      : '-';
+    return (
+      <details key={p.pairId} className="pool-item">
+        <summary>
+          {`${p.dex}${p.version ? ` (${p.version})` : ''} — ${p.base}/${p.quote} — liq $${
+            p.liqUsd ? formatCompact(p.liqUsd) : '-' }
+          `}
+        </summary>
+        <div className="pool-body">
+          <div className="pool-metrics">
+            <div><span>Price USD</span><strong>{formatUsd(p.priceUsd)}</strong></div>
+            <div><span>Price Native</span><strong>{formatUsd(p.priceNative)}</strong></div>
+            <div><span>Txns m5/h1/h6/h24</span><strong>{txStr}</strong></div>
+            <div><span>Vol m5/h1/h6/h24</span><strong>{volStr}</strong></div>
+            <div><span>Δ m5/h1/h6/h24</span><strong>{pcStr}</strong></div>
+            <div><span>Age</span><strong>{age}</strong></div>
           </div>
-          {currentPool && (
-            <div style={{ fontSize: '0.75rem', color: '#666' }}>
-              {currentPool.dex} {currentPool.base}/{currentPool.quote}
-            </div>
+          <div className="pool-links">
+            {p.pairUrl && (
+              <a href={p.pairUrl} target="_blank" rel="noreferrer nofollow">
+                DexScreener
+              </a>
+            )}
+            {p.poolAddress && (
+              <button onClick={() => navigator.clipboard.writeText(p.poolAddress!)}>Copy</button>
+            )}
+            {explorer && (
+              <a href={explorer} target="_blank" rel="noreferrer nofollow">
+                Explorer
+              </a>
+            )}
+          </div>
+          {p.gtSupported === false && (
+            <div className="pool-note">Chart/Trades limited on this DEX.</div>
           )}
         </div>
-        {provider && (
-          <span style={{ fontSize: '0.75rem', border: '1px solid #999', padding: '0 0.25rem' }}>
-            {provider}
-          </span>
-        )}
-      </div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2,1fr)', gap: '0.5rem' }}>
-        <div>
-          <div style={{ fontSize: '0.75rem', color: '#666' }}>Price</div>
-          <div>{kpis.priceUsd !== undefined ? `$${kpis.priceUsd.toFixed(4)}` : '-'}</div>
+      </details>
+    );
+  };
+
+  const desc = info?.description || '';
+  const shortDesc = desc.slice(0, 300);
+
+  return (
+    <div className="detail">
+      {info?.header && <img src={info.header} alt="" className="detail-header" />}
+      <div className="detail-top">
+        <div className="detail-avatar">
+          {info?.imageUrl || meta.icon ? (
+            <img src={info?.imageUrl || meta.icon} alt="" />
+          ) : (
+            <div className="detail-letter">{meta.symbol?.[0] || '?'}</div>
+          )}
         </div>
-        <div>
-          <div style={{ fontSize: '0.75rem', color: '#666' }}>FDV</div>
-          <div>{kpis.fdvUsd !== undefined ? `$${formatCompact(kpis.fdvUsd)}` : '-'}</div>
-        </div>
-        <div>
-          <div style={{ fontSize: '0.75rem', color: '#666' }}>MC</div>
-          <div>{kpis.mcUsd !== undefined ? `$${formatCompact(kpis.mcUsd)}` : '-'}</div>
-        </div>
-        <div>
-          <div style={{ fontSize: '0.75rem', color: '#666' }}>Liquidity</div>
-          <div>{kpis.liqUsd !== undefined ? `$${formatCompact(kpis.liqUsd)}` : '-'}</div>
-        </div>
-        <div>
-          <div style={{ fontSize: '0.75rem', color: '#666' }}>24h Vol</div>
-          <div>{kpis.vol24hUsd !== undefined ? `$${formatCompact(kpis.vol24hUsd)}` : '-'}</div>
-        </div>
-        <div>
-          <div style={{ fontSize: '0.75rem', color: '#666' }}>24h Change</div>
-          <div>{kpis.priceChange24hPct !== undefined ? `${kpis.priceChange24hPct.toFixed(2)}%` : '-'}</div>
-        </div>
-        <div>
-          <div style={{ fontSize: '0.75rem', color: '#666' }}>Age</div>
-          <div>{createdTs ? formatAge(createdTs) : '-'}</div>
+        <div className="detail-overview">
+          <div className="detail-title">
+            <strong>{meta.symbol}</strong> {meta.name}
+          </div>
+          <div className="detail-badges">
+            <span className="badge">{chain}</span>
+            {provider && <span className="badge">{provider}</span>}
+          </div>
         </div>
       </div>
-      <div style={{ marginTop: '0.5rem', display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
-        {links.website && (
-          <a href={links.website} target="_blank" rel="noreferrer" style={{ color: '#4ea3ff', fontSize: '0.75rem' }}>
-            Website
-          </a>
-        )}
-        {links.explorer && (
-          <a href={links.explorer} target="_blank" rel="noreferrer" style={{ color: '#4ea3ff', fontSize: '0.75rem' }}>
-            Explorer
-          </a>
-        )}
-        {links.twitter && (
-          <a href={links.twitter} target="_blank" rel="noreferrer" style={{ color: '#4ea3ff', fontSize: '0.75rem' }}>
-            Twitter
-          </a>
-        )}
-        {links.telegram && (
-          <a href={links.telegram} target="_blank" rel="noreferrer" style={{ color: '#4ea3ff', fontSize: '0.75rem' }}>
-            Telegram
-          </a>
-        )}
+      {desc && (
+        <div className="detail-desc">
+          {descExpanded ? desc : shortDesc}
+          {desc.length > 300 && !descExpanded && (
+            <button className="detail-more" onClick={() => setDescExpanded(true)}>
+              More
+            </button>
+          )}
+        </div>
+      )}
+      {renderLinks()}
+      <div className="detail-kpis">
+        <div><span>Price</span><strong>{formatUsd(kpis.priceUsd)}</strong></div>
+        <div><span>FDV</span><strong>{formatUsd(kpis.fdvUsd)}</strong></div>
+        <div><span>MC</span><strong>{formatUsd(kpis.mcUsd)}</strong></div>
+        <div><span>Liquidity</span><strong>{formatUsd(kpis.liqUsd)}</strong></div>
+        <div><span>24h Vol</span><strong>{formatUsd(kpis.vol24hUsd)}</strong></div>
+        <div>
+          <span>24h %</span>
+          <strong>
+            {kpis.priceChange24hPct !== undefined ? `${kpis.priceChange24hPct.toFixed(2)}%` : '-'}
+          </strong>
+        </div>
+        <div><span>Age</span><strong>{createdTs ? formatAge(createdTs) : '-'}</strong></div>
       </div>
+      <div className="detail-pools">{pairs.map(renderPool)}</div>
       {pools.length > 1 && (
-        <div style={{ marginTop: '0.5rem' }}>
-          <div style={{ fontSize: '0.75rem', marginBottom: '0.25rem' }}>Pools</div>
+        <div className="pool-switcher">
           {pools.map((p) => (
-            <div key={p.pairId} style={{ marginBottom: '0.25rem' }}>
-              <button
-                onClick={() => onSwitch(p)}
-                disabled={p.pairId === pairId}
-                style={{ fontSize: '0.75rem' }}
-              >
-                {`${p.dex}${p.version ? ` (${p.version})` : ''} — ${p.base}/${p.quote}${
-                  p.liqUsd ? ` — $${formatCompact(p.liqUsd)}` : ''
-                }`}
-              </button>
-            </div>
+            <button
+              key={p.pairId}
+              onClick={() => onSwitch(p)}
+              disabled={p.pairId === pairId}
+            >
+              {`${p.dex}${p.version ? ` (${p.version})` : ''} — ${p.base}/${p.quote}${
+                p.liqUsd ? ` — $${formatCompact(p.liqUsd)}` : ''
+              }`}
+            </button>
           ))}
         </div>
       )}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -138,6 +138,14 @@ export interface TokenLinks {
   telegram?: string;
 }
 
+export interface TokenInfoBlock {
+  header?: string;
+  imageUrl?: string;
+  description?: string;
+  websites?: { label?: string; url: string }[];
+  socials?: { type?: string; url: string }[];
+}
+
 export interface TokenPairInfo {
   pairId: PairId;
   dex: string;
@@ -146,12 +154,21 @@ export interface TokenPairInfo {
   pairUrl?: string;
   base?: string;
   quote?: string;
+  liqUsd?: number;
+  priceUsd?: number;
+  priceNative?: number;
+  txns?: { m5?: number; h1?: number; h6?: number; h24?: number };
+  volume?: { m5?: number; h1?: number; h6?: number; h24?: number };
+  priceChange?: { m5?: number; h1?: number; h6?: number; h24?: number };
+  pairCreatedAt?: UnixSeconds;
+  gtSupported?: boolean;
 }
 
 export interface TokenDetail {
   meta: TokenMeta;
   kpis: CoreFinance & { ageDays?: number };
   links: TokenLinks;
+  info?: TokenInfoBlock;
   pairs: TokenPairInfo[];
   provider: Provider;
 }

--- a/src/styles/detail.css
+++ b/src/styles/detail.css
@@ -1,0 +1,23 @@
+.detail { font-size:0.875rem; }
+.detail-header { width:100%; max-height:120px; object-fit:cover; margin-bottom:0.5rem; }
+.detail-top { display:flex; align-items:center; gap:0.5rem; }
+.detail-avatar img { width:40px; height:40px; border-radius:50%; }
+.detail-letter { width:40px; height:40px; border-radius:50%; background:#ccc; display:flex; align-items:center; justify-content:center; font-weight:bold; }
+.detail-title { font-size:1rem; }
+.detail-badges .badge { font-size:0.75rem; border:1px solid #999; padding:0 0.25rem; margin-right:0.25rem; }
+.detail-desc { margin-top:0.5rem; font-size:0.75rem; }
+.detail-more { margin-left:0.25rem; font-size:0.75rem; color:#4ea3ff; }
+.detail-links { margin-top:0.5rem; display:flex; flex-wrap:wrap; gap:0.5rem; }
+.detail-links a { font-size:1rem; text-decoration:none; }
+.detail-kpis { margin-top:0.5rem; display:grid; grid-template-columns:repeat(2,1fr); gap:0.5rem; }
+.detail-kpis span { display:block; font-size:0.75rem; color:#666; }
+.pool-item { margin-top:0.5rem; font-size:0.75rem; }
+.pool-item summary { cursor:pointer; }
+.pool-body { margin-top:0.25rem; }
+.pool-metrics { display:grid; grid-template-columns:repeat(2,1fr); gap:0.25rem; }
+.pool-metrics span { display:block; color:#666; }
+.pool-links { margin-top:0.25rem; display:flex; flex-wrap:wrap; gap:0.5rem; }
+.pool-links a, .pool-links button { font-size:0.75rem; }
+.pool-note { margin-top:0.25rem; font-size:0.7rem; color:#a33; }
+.pool-switcher { margin-top:0.5rem; display:flex; flex-direction:column; gap:0.25rem; }
+.pool-switcher button { font-size:0.75rem; }


### PR DESCRIPTION
## Summary
- merge DexScreener `info` block and detailed pool metrics into token API
- render rich token detail with visuals, links, KPIs, and pool accordion
- add mobile-first styles for detail view

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689efdbcd26c83238569ab3f810e3c9c