### PR TITLE
Add deterministic smoke checks and trade headers

### DIFF
--- a/src/features/chart/ChartPage.tsx
+++ b/src/features/chart/ChartPage.tsx
@@ -83,6 +83,12 @@ export default function ChartPage() {
     setNoData(!p.poolAddress);
   }
 
+  const tradeSymbols = currentPool && token
+    ? token.symbol === currentPool.base
+      ? { baseSymbol: currentPool.base, quoteSymbol: currentPool.quote }
+      : { baseSymbol: currentPool.quote, quoteSymbol: currentPool.base }
+    : null;
+
   return (
     <div style={{ padding: '1rem' }}>
       {token && (
@@ -134,8 +140,8 @@ export default function ChartPage() {
               chain={currentPool.chain}
               poolAddress={currentPool.poolAddress}
               tokenAddress={address}
-              baseSymbol={currentPool.base}
-              quoteSymbol={currentPool.quote}
+              baseSymbol={tradeSymbols?.baseSymbol || currentPool.base}
+              quoteSymbol={tradeSymbols?.quoteSymbol || currentPool.quote}
             />
           )}
           {view === 'detail' && currentPool && address && (


### PR DESCRIPTION
## Summary
- expand smoke script to cover GT-supported, CG-fallback, and unsupported network scenarios
- fix trades table headers to display correct base/quote symbols

## Testing
- `npx ts-node scripts/smoke.ts` *(fails: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f068777b8832385262a8e351a2c57