### PR TITLE
Aggregate token-centric search results

### DIFF
--- a/fixtures/search-ds.json
+++ b/fixtures/search-ds.json
@@ -3,18 +3,17 @@
   "query": "0xabc...",
   "results": [
     {
-      "chain": "ethereum",
-      "token": {
-        "address": "0xabc...",
-        "symbol": "ABC",
-        "name": "Token ABC"
-      },
-      "core": {
-        "priceUsd": 1.22,
-        "liqUsd": 45000,
-        "vol24hUsd": 110000,
-        "priceChange24hPct": 9.8
-      },
+      "address": "0xabc...",
+      "symbol": "ABC",
+      "name": "Token ABC",
+      "priceUsd": 1.22,
+      "liqUsd": 45000,
+      "vol24hUsd": 110000,
+      "chainIcons": ["ethereum"],
+      "poolCount": 1,
+      "gtSupported": false,
+      "provider": "ds",
+      "chainCount": 1,
       "pools": [
         {
           "pairId": "sushiswap_v2_abc_weth",
@@ -23,10 +22,11 @@
           "base": "ABC",
           "quote": "WETH",
           "chain": "ethereum",
-          "poolAddress": "0xpool1"
+          "poolAddress": "0xpool1",
+          "liqUsd": 45000,
+          "gtSupported": false
         }
-      ],
-      "provider": "ds"
+      ]
     }
   ]
 }

--- a/fixtures/search-gt.json
+++ b/fixtures/search-gt.json
@@ -3,21 +3,18 @@
   "query": "0xabc...",
   "results": [
     {
-      "chain": "ethereum",
-      "token": {
-        "address": "0xabc...",
-        "symbol": "ABC",
-        "name": "Token ABC",
-        "icon": "https://example.com/abc.png"
-      },
-      "core": {
-        "priceUsd": 1.23,
-        "fdvUsd": 1000000,
-        "liqUsd": 50000,
-        "vol24hUsd": 120000,
-        "priceChange1hPct": 2.5,
-        "priceChange24hPct": 10.1
-      },
+      "address": "0xabc...",
+      "symbol": "ABC",
+      "name": "Token ABC",
+      "icon": "https://example.com/abc.png",
+      "priceUsd": 1.23,
+      "liqUsd": 50000,
+      "vol24hUsd": 120000,
+      "chainIcons": ["ethereum"],
+      "poolCount": 2,
+      "gtSupported": true,
+      "provider": "gt",
+      "chainCount": 1,
       "pools": [
         {
           "pairId": "uniswap_v2_abc_weth",
@@ -25,7 +22,10 @@
           "version": "v2",
           "base": "ABC",
           "quote": "WETH",
-          "chain": "ethereum"
+          "chain": "ethereum",
+          "poolAddress": "0xpool1",
+          "liqUsd": 30000,
+          "gtSupported": true
         },
         {
           "pairId": "uniswap_v3_abc_usdc",
@@ -33,10 +33,12 @@
           "version": "v3",
           "base": "ABC",
           "quote": "USDC",
-          "chain": "ethereum"
+          "chain": "ethereum",
+          "poolAddress": "0xpool2",
+          "liqUsd": 20000,
+          "gtSupported": true
         }
-      ],
-      "provider": "gt"
+      ]
     }
   ]
 }

--- a/src/features/search/SearchPage.tsx
+++ b/src/features/search/SearchPage.tsx
@@ -1,12 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
-import type { SearchResult, Provider } from '../../lib/types';
+import type { SearchTokenSummary, Provider } from '../../lib/types';
 import { search } from '../../lib/api';
 import copy from '../../copy/en.json';
 import SearchResultItem, { SearchResultSkeleton } from './SearchResultItem';
 
 export default function SearchPage() {
   const [query, setQuery] = useState('');
-  const [results, setResults] = useState<SearchResult[]>([]);
+  const [results, setResults] = useState<SearchTokenSummary[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [provider, setProvider] = useState<Provider | ''>('');
@@ -52,21 +52,17 @@ export default function SearchPage() {
     } else {
       const res = Array.isArray(data.results) ? data.results : [];
       res.forEach((r) =>
-        r.pools.sort((a, b) => {
+        r.pools?.sort((a, b) => {
           const sup = Number(!!b.gtSupported) - Number(!!a.gtSupported);
           if (sup !== 0) return sup;
           return (b.liqUsd || 0) - (a.liqUsd || 0);
         })
       );
       const sorted = res.sort((a, b) => {
-        const aSup = a.pools.some((p) => p.gtSupported);
-        const bSup = b.pools.some((p) => p.gtSupported);
-        if (aSup === bSup) {
-          const aL = a.pools[0]?.liqUsd || 0;
-          const bL = b.pools[0]?.liqUsd || 0;
-          return bL - aL;
+        if (a.gtSupported === b.gtSupported) {
+          return (b.liqUsd || 0) - (a.liqUsd || 0);
         }
-        return aSup ? -1 : 1;
+        return a.gtSupported ? -1 : 1;
       });
       setResults(sorted);
       const first = sorted[0];
@@ -126,18 +122,18 @@ export default function SearchPage() {
             <tr style={{ display: 'grid', gridTemplateColumns: 'repeat(7, minmax(0, 1fr))' }}>
               <th></th>
               <th>Token</th>
-              <th>Chain</th>
               <th>Price</th>
               <th>Liq</th>
               <th>Vol24h</th>
-              <th>%</th>
+              <th>Chains</th>
+              <th>Pools</th>
             </tr>
           </thead>
           <tbody>
             {loading
               ? Array.from({ length: 5 }).map((_, i) => <SearchResultSkeleton key={i} />)
               : results.map((r) => (
-                  <SearchResultItem key={r.token.address + r.chain} result={r} />
+                  <SearchResultItem key={r.address} result={r} />
                 ))}
           </tbody>
         </table>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,17 +46,25 @@ export interface PoolSummary {
 }
 
 /* ---------- /api/search ---------- */
-export interface SearchResult {
-  chain: ChainSlug;
-  token: TokenMeta;
-  core: CoreFinance;
-  pools: PoolSummary[];
+export interface SearchTokenSummary {
+  address: Address;
+  symbol: string;
+  name: string;
+  icon?: string;
+  priceUsd: number;
+  liqUsd: number;
+  vol24hUsd: number;
+  chainIcons: string[]; // up to 3 chains by liquidity
+  poolCount: number;
+  gtSupported: boolean; // true if any pool is supported
   provider: Provider;
+  chainCount?: number; // total distinct chains
+  pools?: PoolSummary[]; // underlying pools for navigation
 }
 
 export interface SearchResponse {
   query: string;           // original user input (address)
-  results: SearchResult[];
+  results: SearchTokenSummary[];
 }
 
 /* ---------- /api/pairs ---------- */


### PR DESCRIPTION
## Summary
- aggregate search API to summarize pools per token across chains
- show one search row per token with chain icons, liquidity, volume and provider badge
- update client navigation to pick the best pool and pass pool address

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f1c7ffe088323b905d094996b314c