### PR TITLE
feat: replace popup search with inline input

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,18 +1,26 @@
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { routes } from './routes';
 import Header from '../components/Header';
 import BottomTabs from '../components/BottomTabs';
+import { ProviderProvider } from '../lib/provider';
 
 function Shell() {
   const location = useLocation();
   const showTabs = location.pathname.startsWith('/t/');
-  const showHeader = location.pathname !== '/';
+
+  useEffect(() => {
+    if (location.pathname === '/') {
+      document.body.classList.add('home-no-header');
+    } else {
+      document.body.classList.remove('home-no-header');
+    }
+  }, [location.pathname]);
 
   return (
     <>
-      {showHeader && <Header />}
-      <main className={`${showTabs ? 'with-tabs' : ''} ${showHeader ? '' : 'no-header'}`}>
+      <Header />
+      <main className={`${showTabs ? 'with-tabs' : ''}`}>
         <Suspense fallback={<div />}>
           <Routes>
             {routes.map((r) => (
@@ -28,8 +36,10 @@ function Shell() {
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Shell />
-    </BrowserRouter>
+    <ProviderProvider>
+      <BrowserRouter>
+        <Shell />
+      </BrowserRouter>
+    </ProviderProvider>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,19 +1,20 @@
 import SearchInput from '../features/search/SearchInput';
+import { useProvider } from '../lib/provider';
 
 export default function Header() {
+  const { provider } = useProvider();
   return (
     <header className="header" style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-      <div style={{ width: 24 }} />
-      <div style={{ flex: 1 }}>
+      <div style={{ flex: 1 }} />
+      <div style={{ flex: 2, maxWidth: 600 }}>
         <SearchInput />
       </div>
-      <div style={{ display: 'flex', gap: '0.5rem' }}>
-        <a href="https://github.com/smol-ai/minidex" target="_blank" rel="noopener noreferrer">
-          GitHub
-        </a>
-        <a href="https://github.com/smol-ai/minidex#readme" target="_blank" rel="noopener noreferrer">
-          Docs
-        </a>
+      <div style={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
+        {provider && (
+          <span className="provider-badge" aria-label={`data provider ${provider}`}>
+            {provider}
+          </span>
+        )}
       </div>
     </header>
   );

--- a/src/features/chart/ChartPage.tsx
+++ b/src/features/chart/ChartPage.tsx
@@ -7,6 +7,7 @@ import ChartOnlyView from './ChartOnlyView';
 import DetailView from './DetailView';
 import TradesOnlyView from '../trades/TradesOnlyView';
 import copy from '../../copy/en.json';
+import { useProvider } from '../../lib/provider';
 
 // Views for chart page
 type View = 'chart' | 'trades' | 'detail';
@@ -25,6 +26,7 @@ export default function ChartPage() {
   const [error, setError] = useState<string | null>(null);
   const [noData, setNoData] = useState(false);
   const [unsupported, setUnsupported] = useState(false);
+  const { setProvider: setGlobalProvider } = useProvider();
 
   useEffect(() => {
     if (!chain || !address) {
@@ -36,6 +38,7 @@ export default function ChartPage() {
     setLoading(true);
     setError(null);
     setProvider(null);
+    setGlobalProvider('');
     pairs(chain, address)
       .then((data) => {
         if (cancelled) return;
@@ -50,6 +53,7 @@ export default function ChartPage() {
         }
         setToken(data.token);
         setProvider(data.provider);
+        setGlobalProvider(data.provider);
         const sorted = data.pools.slice().sort((a, b) => {
           const sup = Number(!!b.gtSupported) - Number(!!a.gtSupported);
           if (sup !== 0) return sup;

--- a/src/features/lists/ListsPage.tsx
+++ b/src/features/lists/ListsPage.tsx
@@ -4,6 +4,7 @@ import type { ListItem as Item, Window, ListsResponse, Provider } from '../../li
 import ListItem from './ListItem';
 import VirtualList from '../../components/VirtualList';
 import { createPoller } from '../../lib/polling';
+import { useProvider } from '../../lib/provider';
 
 const windows: Window[] = ['1h', '1d', '1w'];
 
@@ -14,6 +15,7 @@ export default function ListsPage() {
   const [provider, setProvider] = useState<(Provider | 'none') | undefined>();
   const [sortKey, setSortKey] = useState<keyof Item | 'rank'>('rank');
   const [sortAsc, setSortAsc] = useState(false);
+  const { setProvider: setGlobalProvider } = useProvider();
 
   const fetchLists = useCallback(async () => {
     if (!chain || !type) return;
@@ -29,14 +31,16 @@ export default function ListsPage() {
     const data = (await res.json()) as ListsResponse;
     setItems(data.items);
     setProvider(data.provider);
-  }, [chain, type, windowSel]);
+    setGlobalProvider(data.provider === 'none' ? '' : data.provider);
+  }, [chain, type, windowSel, setGlobalProvider]);
 
   useEffect(() => {
+    setGlobalProvider('');
     fetchLists();
     const poller = createPoller(fetchLists, 60000);
     poller.start();
     return () => poller.stop();
-  }, [fetchLists]);
+  }, [fetchLists, setGlobalProvider]);
 
   function handleSort(key: keyof Item | 'rank') {
     if (sortKey === key) {

--- a/src/lib/provider.tsx
+++ b/src/lib/provider.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, useState } from 'react';
+import type { Provider } from './types';
+
+interface Ctx {
+  provider: Provider | '';
+  setProvider: (p: Provider | '') => void;
+}
+
+const ProviderContext = createContext<Ctx>({ provider: '', setProvider: () => {} });
+
+export function ProviderProvider({ children }: { children: React.ReactNode }) {
+  const [provider, setProvider] = useState<Provider | ''>('');
+  return <ProviderContext.Provider value={{ provider, setProvider }}>{children}</ProviderContext.Provider>;
+}
+
+export function useProvider() {
+  return useContext(ProviderContext);
+}
+

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,6 +18,7 @@ a {
   text-decoration: none;
 }
 
+
 .header {
   position: fixed;
   top: 0;
@@ -31,53 +32,8 @@ a {
   z-index: 10;
 }
 
-.menu-btn {
-  background: none;
-  border: none;
-  color: var(--text);
-  font-size: 1.25rem;
-  cursor: pointer;
-}
-
-.search-pill {
-  flex: 1;
-  margin-left: 0.5rem;
-  background: var(--bg-elev);
-  padding: 0.4rem 0.8rem;
-  border-radius: var(--radius);
-  color: var(--muted);
-  border: none;
-  text-align: left;
-  cursor: pointer;
-}
-
-.menu-btn:focus-visible,
-.search-pill:focus-visible {
-  outline: 2px solid var(--accent-lime);
-}
-
-.menu-sheet {
-  position: absolute;
-  top: 48px;
-  right: 0;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  padding: 0.5rem;
-  z-index: 20;
-}
-
-.menu-sheet ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
 main {
   padding-top: 48px;
-}
-
-main.no-header {
-  padding-top: 0;
 }
 
 main.with-tabs {
@@ -117,6 +73,14 @@ main.with-tabs {
 .list-item-row:focus-visible,
 .search-results-table tr:focus-visible {
   outline: 2px solid var(--accent-lime);
+}
+
+body.home-no-header .header {
+  display: none;
+}
+
+body.home-no-header main {
+  padding-top: 0;
 }
 
 .view-tabs {


### PR DESCRIPTION
## Summary
- add debounced inline SearchInput component
- center SearchInput in header and show provider badge
- hide header on home route via body class

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f1ee69888832390f70669b21a169a