### PR TITLE
feat: add sortable virtualized trades table

### DIFF
--- a/src/lib/format.tsx
+++ b/src/lib/format.tsx
@@ -10,10 +10,20 @@ export function formatCompact(value?: number): string {
   return formatter.format(value);
 }
 
-export function formatUsd(value?: number): string {
+export function formatUsd(
+  value?: number,
+  opts?: { compact?: boolean }
+): string {
   if (value === undefined || value === null || !Number.isFinite(value)) return '-';
-  if (Math.abs(value) >= 1000) return `$${formatCompact(value)}`;
+  if (Math.abs(value) >= 1000 && opts?.compact !== false)
+    return `$${formatCompact(value)}`;
   return `$${value.toFixed(4)}`;
+}
+
+export function formatDateTimeUTC(ts?: number): string {
+  if (!ts && ts !== 0) return '-';
+  const d = new Date(ts * 1000);
+  return d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
 }
 
 export function formatTimeUTC(ts: number): string {

--- a/src/styles/trades.css
+++ b/src/styles/trades.css
@@ -43,23 +43,23 @@
 }
 
 .tr-row {
-  min-height: 44px;
+  min-height: 52px;
   border-bottom: 1px solid var(--border);
 }
-.tr-row:nth-child(odd) { background: var(--bg); }
-.tr-row:nth-child(even) { background: var(--bg-elev); }
 
 .tr-row.buy {
+  background: rgba(163,255,18,0.06);
   color: var(--accent-lime);
 }
 .tr-row.sell {
+  background: rgba(255,46,209,0.06);
   color: var(--accent-magenta);
 }
 .tr-row.buy:hover {
-  background: rgba(163,255,18,0.08);
+  background: rgba(163,255,18,0.12);
 }
 .tr-row.sell:hover {
-  background: rgba(255,46,209,0.08);
+  background: rgba(255,46,209,0.12);
 }
 
 .tr-cell {
@@ -83,4 +83,11 @@
 }
 .tr-link:hover {
   text-decoration: underline;
+}
+
+.tr-pill {
+  background: var(--border);
+  border-radius: 1rem;
+  padding: 0 0.5rem;
+  font-size: 0.75rem;
 }


### PR DESCRIPTION
## Summary
- add UTC date formatting and optional compact flag for USD formatting
- implement virtualized, sortable trades table with per-maker counts
- style trade rows with buy/sell tints and pill badges

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f23c5f06c8323b17ce7984e296ded