### PR TITLE
Refactor search result handling

### DIFF
--- a/src/features/search/SearchInput.tsx
+++ b/src/features/search/SearchInput.tsx
@@ -35,7 +35,7 @@ export default function SearchInput({ autoFocus, large }: Props) {
     const controller = new AbortController();
     abortRef.current = controller;
     apiSearch(q, undefined, controller.signal)
-      .then((data) => {
+      .then(({ data }) => {
         if ('results' in data) {
           setResults(Array.isArray(data.results) ? data.results : []);
         } else {


### PR DESCRIPTION
## Summary
- Destructure ApiResult data in search API handler
- Guard result state update by checking for 'results'

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f684ecb388323bd82ea8ae980cad6