### PR TITLE
fix: remove latest suffix from DexScreener base

### DIFF
--- a/netlify/functions/token.ts
+++ b/netlify/functions/token.ts
@@ -5,6 +5,7 @@ import { isGtSupported } from '../shared/dex-allow';
 const CG_API_BASE = process.env.COINGECKO_API_BASE || '';
 const CG_API_KEY = process.env.COINGECKO_API_KEY || '';
 const DS_API_BASE = process.env.DS_API_BASE || '';
+const dsBase = DS_API_BASE.replace(/\/latest$/, '');
 const DEBUG = process.env.DEBUG_LOGS === 'true';
 
 function log(...args: any[]) {
@@ -81,7 +82,7 @@ export const handler: Handler = async (event) => {
   if (DS_API_BASE) {
     try {
       attempted.push('ds');
-      const res = await fetch(`${DS_API_BASE}/token-pairs/v1/${chain}/${address}`);
+      const res = await fetch(`${dsBase}/token-pairs/v1/${chain}/${address}`);
       if (res.ok) {
         const ds = await res.json();
         info = ds.info;


### PR DESCRIPTION
## Summary
- strip trailing `/latest` from DexScreener API base
- use normalized base when fetching token-pairs data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f6ed144a48323b8bd01c55a649b3f