### PR TITLE
feat: polish trades table and theme

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -6,25 +6,32 @@ interface Props {
 
 export default function CopyButton({ text }: Props) {
   const [copied, setCopied] = useState(false);
-
-  async function handleClick() {
+  async function copy() {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
-      setTimeout(() => setCopied(false), 1000);
+      setTimeout(() => setCopied(false), 1500);
     } catch {
       /* ignore */
     }
   }
 
+  function handleKey(e: React.KeyboardEvent<HTMLButtonElement>) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      copy();
+    }
+  }
+
   return (
     <button
-      onClick={handleClick}
+      onClick={copy}
+      onKeyDown={handleKey}
       className="copy-btn"
-      title={copied ? 'Copied' : 'Copy'}
       aria-label="copy"
     >
       📋
+      {copied && <span className="tooltip">Copied</span>}
     </button>
   );
 }

--- a/src/features/chart/DetailView.tsx
+++ b/src/features/chart/DetailView.tsx
@@ -3,7 +3,7 @@ import type { PoolSummary, TokenResponse } from '../../lib/types';
 import { token as fetchToken } from '../../lib/api';
 import { formatUsd, formatCompact, formatAge } from '../../lib/format';
 import CopyButton from '../../components/CopyButton';
-import { explorer } from '../../lib/explorer';
+import { addressUrl } from '../../lib/explorer';
 import '../../styles/detail.css';
 
 interface Props {
@@ -67,9 +67,11 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
   info.websites?.forEach((w) => linkItems.push({ key: (w.label || 'website').toLowerCase(), url: w.url }));
   info.socials?.forEach((s) => linkItems.push({ key: (s.type || '').toLowerCase(), url: s.url }));
 
-  const pairExplorer = explorer(chain, active.pairAddress);
-  const baseExplorer = explorer(chain, active.baseToken.address);
-  const quoteExplorer = explorer(chain, active.quoteToken.address);
+  const pairExplorer = active.pairAddress
+    ? addressUrl(chain as any, active.pairAddress)
+    : undefined;
+  const baseExplorer = addressUrl(chain as any, active.baseToken.address as any);
+  const quoteExplorer = addressUrl(chain as any, active.quoteToken.address as any);
 
   const otherPools = detail.pools.filter((p) => p.pairId !== active.pairId);
 
@@ -146,7 +148,22 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
         <div><span>Liquidity $</span><strong>{formatUsd(kpis.liqUsd)}</strong></div>
         <div><span>FDV $</span><strong>{formatUsd(kpis.fdvUsd)}</strong></div>
         <div><span>MC $</span><strong>{formatUsd(kpis.mcUsd)}</strong></div>
-        <div><span>24h %</span><strong>{kpis.priceChange24hPct !== undefined ? `${kpis.priceChange24hPct.toFixed(2)}%` : '-'}</strong></div>
+        <div>
+          <span>24h %</span>
+          <strong
+            className={
+              kpis.priceChange24hPct !== undefined
+                ? kpis.priceChange24hPct < 0
+                  ? 'neg'
+                  : 'pos'
+                : undefined
+            }
+          >
+            {kpis.priceChange24hPct !== undefined
+              ? `${kpis.priceChange24hPct.toFixed(2)}%`
+              : '-'}
+          </strong>
+        </div>
         <div><span>Age</span><strong>{ageText}</strong></div>
       </div>
 
@@ -174,8 +191,8 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
           <div>
             Pair: {active.pairAddress}
             <CopyButton text={active.pairAddress} />
-            {pairExplorer.address && (
-              <a href={pairExplorer.address} target="_blank" rel="noopener noreferrer">
+            {pairExplorer && (
+              <a href={pairExplorer} target="_blank" rel="noopener noreferrer">
                 ↗
               </a>
             )}
@@ -184,8 +201,8 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
         <div>
           {active.baseToken.symbol}: {active.baseToken.address}
           <CopyButton text={active.baseToken.address} />
-          {baseExplorer.address && (
-            <a href={baseExplorer.address} target="_blank" rel="noopener noreferrer">
+          {baseExplorer && (
+            <a href={baseExplorer} target="_blank" rel="noopener noreferrer">
               ↗
             </a>
           )}
@@ -193,8 +210,8 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
         <div>
           {active.quoteToken.symbol}: {active.quoteToken.address}
           <CopyButton text={active.quoteToken.address} />
-          {quoteExplorer.address && (
-            <a href={quoteExplorer.address} target="_blank" rel="noopener noreferrer">
+          {quoteExplorer && (
+            <a href={quoteExplorer} target="_blank" rel="noopener noreferrer">
               ↗
             </a>
           )}

--- a/src/features/trades/TradesOnlyView.tsx
+++ b/src/features/trades/TradesOnlyView.tsx
@@ -10,6 +10,7 @@ import {
   formatFetchMeta,
   type FetchMeta,
 } from '../../lib/format';
+import { addressUrl, txUrl } from '../../lib/explorer';
 import '../../styles/trades.css';
 
 const ROW_HEIGHT = 52;
@@ -40,6 +41,7 @@ interface ColumnConfig {
   accessor: (t: Trade) => any;
   render: (t: Trade) => ReactNode;
   comparator?: (a: any, b: any) => number;
+  className?: string;
 }
 
 export default function TradesOnlyView({
@@ -118,6 +120,7 @@ export default function TradesOnlyView({
         accessor: (t) => t.side,
         render: (t) => t.side,
         comparator: (a: string, b: string) => a.localeCompare(b),
+        className: 'type',
       },
       {
         key: 'price',
@@ -157,7 +160,7 @@ export default function TradesOnlyView({
           t.wallet ? (
             <a
               className="tr-link"
-              href={`https://etherscan.io/address/${t.wallet}`}
+              href={addressUrl(chain as any, t.wallet)!}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -176,7 +179,7 @@ export default function TradesOnlyView({
           t.txHash ? (
             <a
               className="tr-link"
-              href={`https://etherscan.io/tx/${t.txHash}`}
+              href={txUrl(chain as any, t.txHash)!}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -204,7 +207,7 @@ export default function TradesOnlyView({
         comparator: (a: number, b: number) => a - b,
       },
     ],
-    [baseSymbol, quoteSymbol, counts]
+    [baseSymbol, quoteSymbol, counts, chain]
   );
 
   const sorted = useMemo(() => {
@@ -240,7 +243,7 @@ export default function TradesOnlyView({
     return (
       <div style={style} className={`tr-row ${typeClass}`}>
         {columns.map((c) => (
-          <div key={c.key} className="tr-cell">
+          <div key={c.key} className={`tr-cell${c.className ? ' ' + c.className : ''}`}>
             {c.render(t)}
           </div>
         ))}

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -2,19 +2,28 @@ import type { ChainSlug, Address, TxHash } from './types';
 
 const BASES: Record<string, string> = {
   ethereum: 'https://etherscan.io',
-  arbitrum: 'https://arbiscan.io',
-  polygon: 'https://polygonscan.com',
   bsc: 'https://bscscan.com',
   base: 'https://basescan.org',
+  arbitrum: 'https://arbiscan.io',
+  polygon: 'https://polygonscan.com',
   optimism: 'https://optimistic.etherscan.io',
   avalanche: 'https://snowtrace.io',
 };
 
-export function explorer(chain: ChainSlug, addr?: Address, tx?: TxHash) {
+export function addressUrl(chain: ChainSlug, addr: Address) {
   const base = BASES[chain];
-  if (!base) return { address: undefined, tx: undefined };
+  return base ? `${base}/address/${addr}` : undefined;
+}
+
+export function txUrl(chain: ChainSlug, hash: TxHash) {
+  const base = BASES[chain];
+  return base ? `${base}/tx/${hash}` : undefined;
+}
+
+// backwards compat for older callers
+export function explorer(chain: ChainSlug, addr?: Address, tx?: TxHash) {
   return {
-    address: addr ? `${base}/address/${addr}` : undefined,
-    tx: tx ? `${base}/tx/${tx}` : undefined,
+    address: addr ? addressUrl(chain, addr) : undefined,
+    tx: tx ? txUrl(chain, tx) : undefined,
   };
 }

--- a/src/styles/detail.css
+++ b/src/styles/detail.css
@@ -1,33 +1,36 @@
 .detail { font-size:0.875rem; }
 .detail-header-wrap { position:relative; margin-bottom:-20px; }
 .detail-header { width:100%; object-fit:cover; aspect-ratio:16/6; display:block; }
-.detail-top { display:flex; align-items:center; gap:calc(var(--padding)/2); background:var(--bg-elev); padding:calc(var(--padding)/2); border-radius:var(--card-radius); }
+.detail-top { display:flex; align-items:center; gap:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
 .detail-avatar img { width:72px; height:72px; border-radius:50%; }
 .detail-letter { width:40px; height:40px; border-radius:50%; background:var(--bg-elev); color:var(--text); display:flex; align-items:center; justify-content:center; font-weight:bold; }
 .detail-title { font-size:1rem; }
-.detail-badges .badge { font-size:0.75rem; border:1px solid var(--border); padding:0 calc(var(--padding)/4); margin-right:calc(var(--padding)/4); border-radius:var(--card-radius); }
+.detail-badges .badge { font-size:0.75rem; border:1px solid var(--border); padding:0 var(--space-1); margin-right:var(--space-1); border-radius:var(--radius); }
 .detail-badges .badge.limited { border-color:var(--accent-magenta); color:var(--accent-magenta); }
-.detail-desc { margin-top:calc(var(--padding)/2); font-size:0.75rem; background:var(--bg-elev); padding:calc(var(--padding)/2); border-radius:var(--card-radius); }
-.detail-more { margin-left:calc(var(--padding)/4); font-size:0.75rem; color:var(--accent-cyan); }
-.detail-links { margin-top:calc(var(--padding)/2); display:flex; flex-wrap:wrap; gap:calc(var(--padding)/2); background:var(--bg-elev); padding:calc(var(--padding)/2); border-radius:var(--card-radius); }
+.detail-desc { margin-top:var(--space-2); font-size:0.75rem; background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
+.detail-more { margin-left:var(--space-1); font-size:0.75rem; color:var(--accent-cyan); }
+.detail-links { margin-top:var(--space-2); display:flex; flex-wrap:wrap; gap:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
 .detail-links a { font-size:1rem; text-decoration:none; }
-.detail-kpis { margin-top:calc(var(--padding)/2); display:grid; grid-template-columns:repeat(2,1fr); gap:calc(var(--padding)/2); background:var(--bg-elev); padding:calc(var(--padding)/2); border-radius:var(--card-radius); }
+.detail-kpis { margin-top:var(--space-2); display:grid; grid-template-columns:repeat(2,1fr); gap:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
 .detail-kpis span { display:block; font-size:0.75rem; color:var(--text-muted); }
-.detail-kpis strong { color:var(--accent-lime); }
-.pool-item { margin-top:calc(var(--padding)/2); font-size:0.75rem; background:var(--bg-elev); padding:calc(var(--padding)/2); border-radius:var(--card-radius); }
+.detail-kpis strong { color:var(--text); font-weight:bold; }
+.detail-kpis strong.pos { color:var(--accent-lime); }
+.detail-kpis strong.neg { color:var(--accent-magenta); }
+.pool-item { margin-top:var(--space-2); font-size:0.75rem; background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
 .pool-item summary { cursor:pointer; }
-.pool-body { margin-top:0.25rem; }
-.pool-metrics { display:grid; grid-template-columns:repeat(2,1fr); gap:0.25rem; }
+.pool-body { margin-top:var(--space-1); }
+.pool-metrics { display:grid; grid-template-columns:repeat(2,1fr); gap:var(--space-1); }
 .pool-metrics span { display:block; color:var(--text-muted); }
-.pool-metrics strong { color:var(--accent-lime); }
-.pool-links { margin-top:calc(var(--padding)/4); display:flex; flex-wrap:wrap; gap:calc(var(--padding)/2); }
+.pool-metrics strong { color:var(--text); font-weight:bold; }
+.pool-metrics strong.pos { color:var(--accent-lime); }
+.pool-metrics strong.neg { color:var(--accent-magenta); }
+.pool-links { margin-top:var(--space-1); display:flex; flex-wrap:wrap; gap:var(--space-2); }
 .pool-links a, .pool-links button { font-size:0.75rem; }
-.pool-note { margin-top:calc(var(--padding)/4); font-size:0.7rem; color:var(--accent-magenta); }
-.pool-switcher { margin-top:calc(var(--padding)/2); display:flex; flex-direction:column; gap:calc(var(--padding)/4); }
+.pool-note { margin-top:var(--space-1); font-size:0.7rem; color:var(--accent-magenta); }
+.pool-switcher { margin-top:var(--space-2); display:flex; flex-direction:column; gap:var(--space-1); }
 .pool-switcher button { font-size:0.75rem; }
 
-.copy-btn { background:none; border:none; cursor:pointer; margin-left:4px; }
-.detail-addrs div { margin-top:0.25rem; display:flex; align-items:center; gap:4px; }
-.detail-extra { margin-top:calc(var(--padding)/2); background:var(--bg-elev); padding:calc(var(--padding)/2); border-radius:var(--card-radius); }
-.detail-row { margin-bottom:0.25rem; }
-.switch-btn { margin-top:0.25rem; font-size:0.75rem; }
+.detail-addrs div { margin-top:var(--space-1); display:flex; align-items:center; gap:var(--space-1); }
+.detail-extra { margin-top:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
+.detail-row { margin-bottom:var(--space-1); }
+.switch-btn { margin-top:var(--space-1); font-size:0.75rem; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,7 +27,7 @@ a {
   height: 48px;
   display: flex;
   align-items: center;
-  padding: 0 1rem;
+  padding: 0 var(--space-4);
   background: var(--bg-elev);
   z-index: 10;
 }
@@ -86,13 +86,13 @@ body.home-no-header main {
 }
 
 .view-tabs {
-  margin-bottom: var(--padding);
+  margin-bottom: var(--space-4);
 }
 
 .view-tab {
-  margin-right: calc(var(--padding) / 2);
+  margin-right: var(--space-2);
   min-height: 44px;
-  padding: 0 calc(var(--padding) / 2);
+  padding: 0 var(--space-2);
 }
 
 .view-tab[aria-selected='true'] {
@@ -113,7 +113,7 @@ button:focus-visible {
 .search-results-table {
   width: 100%;
   border-collapse: collapse;
-  margin-top: calc(var(--padding) / 2);
+  margin-top: var(--space-2);
   table-layout: fixed;
 }
 
@@ -126,7 +126,7 @@ button:focus-visible {
 
 .search-results-table th,
 .search-results-table td {
-  padding: 0.75rem;
+  padding: var(--space-3);
   border-bottom: 1px solid var(--border);
   text-align: left;
   overflow: hidden;
@@ -153,14 +153,14 @@ tbody tr:nth-child(even) {
 .provider-badge {
   font-size: 0.75rem;
   border: 1px solid var(--border);
-  padding: 0 calc(var(--padding) / 4);
+  padding: 0 var(--space-1);
 }
 
 .error-banner {
   background: rgba(255, 46, 209, 0.1);
   color: var(--accent-magenta);
-  padding: calc(var(--padding) / 2);
-  margin-bottom: calc(var(--padding) / 2);
+  padding: var(--space-2);
+  margin-bottom: var(--space-2);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -168,9 +168,32 @@ tbody tr:nth-child(even) {
 
 .no-results {
   color: var(--text-muted);
-  margin-top: calc(var(--padding) / 2);
+  margin-top: var(--space-2);
 }
 
 .trending-section {
-  margin-top: var(--padding);
+  margin-top: var(--space-4);
+}
+
+.copy-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  position: relative;
+  margin-left: var(--space-1);
+  color: inherit;
+}
+
+.copy-btn .tooltip {
+  position: absolute;
+  top: -1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-elev);
+  color: var(--text);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  pointer-events: none;
+  white-space: nowrap;
 }

--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -12,15 +12,15 @@
   margin-left: -8px;
 }
 .chain-more {
-  margin-left: 4px;
+  margin-left: var(--space-1);
   font-size: 0.75rem;
   background: var(--bg-elev);
-  padding: 0 4px;
-  border-radius: 4px;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius);
 }
 .pool-count-chip {
   font-size: 0.75rem;
   background: var(--bg-elev);
-  padding: 0 4px;
-  border-radius: 4px;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius);
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -8,6 +8,13 @@
   --accent-magenta: #ff2ed1;
   --accent-cyan: #00e0ff;
   --border: #282c34;
-  --card-radius: 12px;
-  --padding: 16px;
+  --radius: 12px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+
+  /* legacy tokens */
+  --card-radius: var(--radius);
+  --padding: var(--space-4);
 }

--- a/src/styles/trades.css
+++ b/src/styles/trades.css
@@ -49,11 +49,9 @@
 
 .tr-row.buy {
   background: rgba(140,255,0,0.06);
-  color: var(--accent-lime);
 }
 .tr-row.sell {
   background: rgba(255,46,209,0.06);
-  color: var(--accent-magenta);
 }
 .tr-row.buy:hover {
   background: rgba(140,255,0,0.12);
@@ -63,7 +61,7 @@
 }
 
 .tr-cell {
-  padding: calc(var(--padding) / 4) calc(var(--padding) / 2);
+  padding: var(--space-1) var(--space-2);
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -87,7 +85,14 @@
 
 .tr-pill {
   background: var(--border);
-  border-radius: var(--card-radius);
-  padding: 0 calc(var(--padding) / 2);
+  border-radius: var(--radius);
+  padding: 0 var(--space-2);
   font-size: 0.75rem;
+}
+
+.tr-row.buy .tr-cell.type {
+  color: var(--accent-lime);
+}
+.tr-row.sell .tr-cell.type {
+  color: var(--accent-magenta);
 }


### PR DESCRIPTION
## Summary
- add chain-aware explorer URL helpers and accessible CopyButton tooltip
- unify theme spacing tokens and KPI styling across detail, trades, search
- enhance trades table with typed column configs, maker group counts, and chain-specific links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f7b2432548323af043cc91d92b5a7