### PR TITLE
Harden token endpoint with dexscreener fallbacks

### DIFF
--- a/netlify/shared/http.ts
+++ b/netlify/shared/http.ts
@@ -1,0 +1,15 @@
+export async function getJson(url: string, init?: RequestInit): Promise<any | null> {
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) return null;
+    const text = await res.text();
+    if (!text) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- sanitize DexScreener base URL and lowercase address
- add DexScreener search, GeckoTerminal, and CoinGecko info fallbacks
- return 200 with minimal payload when upstream data missing
- guard chart `setVisibleRange` with data checks and requestAnimationFrame to avoid crashes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f8b8145d883239b99795e2f1ac9a7