### PR TITLE
Use sanitized dsBase in token function

### DIFF
--- a/netlify/functions/token.ts
+++ b/netlify/functions/token.ts
@@ -87,7 +87,7 @@ export const handler: Handler = async (event) => {
     let provider: 'ds' | 'cg' | undefined;
     const kpis: any = {};
 
-    if (DS_API_BASE) {
+    if (dsBase) {
       try {
         attempted.push('ds');
         const res = await fetch(`${dsBase}/token-pairs/v1/${chain}/${address.toLowerCase()}`);


### PR DESCRIPTION
## Summary
- call DexScreener token lookup unconditionally with sanitized `dsBase`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `node - <<'NODE' ...` with `DS_API_BASE` unset
- `DS_API_BASE='http://localhost:1' node - <<'NODE' ...`


------
https://chatgpt.com/codex/tasks/task_e_689f9cd5cb948323affb15d028869332