### PR TITLE
feat: enhance detail view and pool switching

### DIFF
--- a/src/features/chart/ChartPage.tsx
+++ b/src/features/chart/ChartPage.tsx
@@ -127,7 +127,7 @@ export default function ChartPage() {
 
       {!loading && !error && pools.length > 0 && (
         <>
-          {view !== 'detail' && pools.length > 1 && pools.length <= 3 && (
+          {pools.length > 1 && pools.length <= 3 && (
             <PoolSwitcher
               pools={pools}
               current={currentPool?.pairId}

--- a/src/features/chart/PoolSwitcher.tsx
+++ b/src/features/chart/PoolSwitcher.tsx
@@ -26,7 +26,7 @@ export default function PoolSwitcher({ pools, current, onSwitch }: Props) {
             opacity: p.gtSupported === false ? 0.5 : 1,
           }}
         >
-          {p.dex} {p.base}/{p.quote}
+          {p.dex} {p.version ? `(${p.version})` : ''} {p.base}/{p.quote}
           {p.gtSupported === false && (
             <span
               style={{

--- a/src/styles/detail.css
+++ b/src/styles/detail.css
@@ -1,36 +1,35 @@
 .detail { font-size:0.875rem; }
-.detail-header-wrap { position:relative; margin-bottom:-20px; }
+.detail-header-wrap { position:relative; }
+.detail-header-wrap::after { content:""; position:absolute; inset:0; background:linear-gradient(to bottom,rgba(0,0,0,0),var(--bg)); }
 .detail-header { width:100%; object-fit:cover; aspect-ratio:16/6; display:block; }
-.detail-top { display:flex; align-items:center; gap:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
-.detail-avatar img { width:72px; height:72px; border-radius:50%; }
+.detail-top { margin-top:-48px; display:flex; align-items:center; gap:var(--space-2); background:var(--bg-elev); padding:calc(var(--space-2) + 48px) var(--space-2) var(--space-2); border-radius:var(--radius); }
+.detail-avatar img { width:96px; height:96px; border-radius:50%; }
 .detail-letter { width:40px; height:40px; border-radius:50%; background:var(--bg-elev); color:var(--text); display:flex; align-items:center; justify-content:center; font-weight:bold; }
-.detail-title { font-size:1rem; }
-.detail-badges .badge { font-size:0.75rem; border:1px solid var(--border); padding:0 var(--space-1); margin-right:var(--space-1); border-radius:var(--radius); }
-.detail-badges .badge.limited { border-color:var(--accent-magenta); color:var(--accent-magenta); }
+.detail-title { font-size:1.25rem; font-weight:bold; }
+.detail-subline { margin-top:var(--space-1); font-size:0.875rem; display:flex; align-items:center; gap:var(--space-1); flex-wrap:wrap; }
+.detail-subline .badge { font-size:0.75rem; border:1px solid var(--border); padding:0 var(--space-1); border-radius:var(--radius); }
+.detail-subline .badge.limited { border-color:var(--accent-magenta); color:var(--accent-magenta); }
 .detail-desc { margin-top:var(--space-2); font-size:0.75rem; background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
 .detail-more { margin-left:var(--space-1); font-size:0.75rem; color:var(--accent-cyan); }
-.detail-links { margin-top:var(--space-2); display:flex; flex-wrap:wrap; gap:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
-.detail-links a { font-size:1rem; text-decoration:none; }
-.detail-kpis { margin-top:var(--space-2); display:grid; grid-template-columns:repeat(2,1fr); gap:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
+.detail-kpis { margin-top:var(--space-2); display:grid; grid-template-columns:repeat(auto-fit,minmax(120px,1fr)); gap:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
 .detail-kpis span { display:block; font-size:0.75rem; color:var(--text-muted); }
 .detail-kpis strong { color:var(--text); font-weight:bold; }
-.detail-kpis strong.pos { color:var(--accent-lime); }
-.detail-kpis strong.neg { color:var(--accent-magenta); }
+.detail-kpis strong.pos, .detail-kpis span.pos { color:var(--accent-lime); }
+.detail-kpis strong.neg, .detail-kpis span.neg { color:var(--accent-magenta); }
+.detail-links { margin-top:var(--space-2); display:flex; flex-wrap:wrap; gap:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
+.detail-links a { font-size:1rem; text-decoration:none; }
 .pool-item { margin-top:var(--space-2); font-size:0.75rem; background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
 .pool-item summary { cursor:pointer; }
 .pool-body { margin-top:var(--space-1); }
-.pool-metrics { display:grid; grid-template-columns:repeat(2,1fr); gap:var(--space-1); }
+.pool-metrics { display:grid; grid-template-columns:repeat(auto-fit,minmax(100px,1fr)); gap:var(--space-1); }
 .pool-metrics span { display:block; color:var(--text-muted); }
 .pool-metrics strong { color:var(--text); font-weight:bold; }
-.pool-metrics strong.pos { color:var(--accent-lime); }
-.pool-metrics strong.neg { color:var(--accent-magenta); }
+.pool-metrics strong.pos, .pool-metrics span.pos { color:var(--accent-lime); }
+.pool-metrics strong.neg, .pool-metrics span.neg { color:var(--accent-magenta); }
 .pool-links { margin-top:var(--space-1); display:flex; flex-wrap:wrap; gap:var(--space-2); }
 .pool-links a, .pool-links button { font-size:0.75rem; }
 .pool-note { margin-top:var(--space-1); font-size:0.7rem; color:var(--accent-magenta); }
 .pool-switcher { margin-top:var(--space-2); display:flex; flex-direction:column; gap:var(--space-1); }
 .pool-switcher button { font-size:0.75rem; }
-
+.detail-addrs { margin-top:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
 .detail-addrs div { margin-top:var(--space-1); display:flex; align-items:center; gap:var(--space-1); }
-.detail-extra { margin-top:var(--space-2); background:var(--bg-elev); padding:var(--space-2); border-radius:var(--radius); }
-.detail-row { margin-bottom:var(--space-1); }
-.switch-btn { margin-top:var(--space-1); font-size:0.75rem; }


### PR DESCRIPTION
## Summary
- add header image, avatar, and token subline in detail view
- show active pool KPIs and per-pool metrics with switcher
- enable pool pills for small sets and include version labels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a05583ffec8323993cd2399719eb47