### PR TITLE
feat: polish search, trades, and copy UX

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,16 +1,18 @@
 import { useState } from 'react';
+import '../styles/tooltips.css';
 
 interface Props {
   text: string;
+  label?: string;
 }
 
-export default function CopyButton({ text }: Props) {
+export default function CopyButton({ text, label }: Props) {
   const [copied, setCopied] = useState(false);
   async function copy() {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      setTimeout(() => setCopied(false), 1200);
     } catch {
       /* ignore */
     }
@@ -25,10 +27,11 @@ export default function CopyButton({ text }: Props) {
 
   return (
     <button
+      type="button"
       onClick={copy}
       onKeyDown={handleKey}
       className="copy-btn"
-      aria-label="copy"
+      aria-label={label ? `Copy ${label}` : 'Copy'}
     >
       📋
       {copied && <span className="tooltip">Copied</span>}

--- a/src/features/chart/ChartPage.tsx
+++ b/src/features/chart/ChartPage.tsx
@@ -8,6 +8,7 @@ import DetailView from './DetailView';
 import TradesOnlyView from '../trades/TradesOnlyView';
 import copy from '../../copy/en.json';
 import { useProvider } from '../../lib/provider';
+import { resolvePairSymbols } from '../../lib/pairs';
 
 // Views for chart page
 type View = 'chart' | 'trades' | 'detail';
@@ -97,11 +98,8 @@ export default function ChartPage() {
     requestAnimationFrame(() => window.scrollTo(0, scroll));
   }
 
-  const tradeSymbols = currentPool && token
-    ? token.symbol === currentPool.base
-      ? { baseSymbol: currentPool.base, quoteSymbol: currentPool.quote }
-      : { baseSymbol: currentPool.quote, quoteSymbol: currentPool.base }
-    : null;
+  const tradeSymbols =
+    currentPool && token ? resolvePairSymbols(token.symbol, currentPool) : null;
 
   return (
     <div style={{ padding: '1rem' }}>

--- a/src/features/chart/DetailView.tsx
+++ b/src/features/chart/DetailView.tsx
@@ -197,7 +197,7 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
         {active.pairAddress && (
           <div>
             Pair: {active.pairAddress}
-            <CopyButton text={active.pairAddress} />
+            <CopyButton text={active.pairAddress} label="pair address" />
             {pairExplorer && (
               <a href={pairExplorer} target="_blank" rel="noopener noreferrer">
                 ↗
@@ -207,7 +207,7 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
         )}
         <div>
           {active.baseToken.symbol}: {active.baseToken.address}
-          <CopyButton text={active.baseToken.address} />
+          <CopyButton text={active.baseToken.address} label={`${active.baseToken.symbol} address`} />
           {baseExplorer && (
             <a href={baseExplorer} target="_blank" rel="noopener noreferrer">
               ↗
@@ -216,7 +216,7 @@ export default function DetailView({ chain, address, pairId, pools, onSwitch }: 
         </div>
         <div>
           {active.quoteToken.symbol}: {active.quoteToken.address}
-          <CopyButton text={active.quoteToken.address} />
+          <CopyButton text={active.quoteToken.address} label={`${active.quoteToken.symbol} address`} />
           {quoteExplorer && (
             <a href={quoteExplorer} target="_blank" rel="noopener noreferrer">
               ↗

--- a/src/features/search/SearchResultItem.tsx
+++ b/src/features/search/SearchResultItem.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import type { SearchTokenSummary, PoolSummary } from '../../lib/types';
 import { formatUsd } from '../../lib/format';
+import { CHAIN_TO_ICON } from '../../lib/chains';
 
 interface Props { result: SearchTokenSummary }
 
@@ -125,15 +126,22 @@ export default function SearchResultItem({ result }: Props) {
         {formatUsd(vol24hUsd)}
       </td>
       <td>
-        <div className="chain-icons">
-          {displayedChains.map((c, i) => (
-            <img
-              key={c}
-              src={`https://icons.llamao.fi/icons/chains/rsz_${c}.jpg`}
-              alt={c}
-              style={{ zIndex: displayedChains.length - i }}
-            />
-          ))}
+        <div
+          className="chain-icons"
+          title={(chainIcons || []).join(', ')}
+        >
+          {displayedChains.map((c, i) => {
+            const url = CHAIN_TO_ICON[c];
+            if (!url) return null;
+            return (
+              <img
+                key={c}
+                src={url}
+                alt={c}
+                style={{ zIndex: displayedChains.length - i }}
+              />
+            );
+          })}
           {chainCount && chainCount > displayedChains.length && (
             <span className="chain-more">+{chainCount - displayedChains.length}</span>
           )}

--- a/src/features/trades/TradesOnlyView.tsx
+++ b/src/features/trades/TradesOnlyView.tsx
@@ -32,8 +32,7 @@ type SortKey =
   | 'amountBase'
   | 'amountQuote'
   | 'wallet'
-  | 'tx'
-  | 'txCount';
+  | 'tx';
 
 interface ColumnConfig {
   key: SortKey;
@@ -90,14 +89,6 @@ export default function TradesOnlyView({
     };
   }, [pairId, chain, poolAddress, tokenAddress]);
 
-  const counts = useMemo(() => {
-    const m = new Map<string, number>();
-    rows.forEach((r) => {
-      if (r.wallet) m.set(r.wallet, (m.get(r.wallet) || 0) + 1);
-    });
-    return m;
-  }, [rows]);
-
   const columns: ColumnConfig[] = useMemo(
     () => [
       {
@@ -126,7 +117,7 @@ export default function TradesOnlyView({
         key: 'price',
         header: 'Price $',
         accessor: (t) => t.price,
-        render: (t) => formatUsd(t.price, { compact: true }),
+        render: (t) => formatUsd(t.price, { compact: true, dp: 4 }),
         comparator: (a: number | undefined, b: number | undefined) =>
           (a || 0) - (b || 0),
       },
@@ -158,18 +149,22 @@ export default function TradesOnlyView({
         accessor: (t) => t.wallet || '',
         render: (t) =>
           t.wallet ? (
-            <a
-              className="tr-link"
-              href={addressUrl(chain as any, t.wallet)!}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {formatShortAddr(t.wallet)} ↗
-            </a>
+            <>
+              {formatShortAddr(t.wallet)}
+              <a
+                className="tr-link"
+                href={addressUrl(chain as any, t.wallet)!}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                ↗
+              </a>
+            </>
           ) : (
             '-'
           ),
         comparator: (a: string, b: string) => a.localeCompare(b),
+        className: 'maker',
       },
       {
         key: 'tx',
@@ -190,24 +185,8 @@ export default function TradesOnlyView({
           ),
         comparator: (a: string, b: string) => a.localeCompare(b),
       },
-      {
-        key: 'txCount',
-        header: 'TX Sum',
-        accessor: (t) => (t.wallet ? counts.get(t.wallet) || 0 : 0),
-        render: (t) => {
-          const cnt = t.wallet ? counts.get(t.wallet) || 0 : 0;
-          return t.wallet ? (
-            <span className="tr-pill">
-              {cnt} {cnt === 1 ? 'trade' : 'trades'}
-            </span>
-          ) : (
-            '-'
-          );
-        },
-        comparator: (a: number, b: number) => a - b,
-      },
     ],
-    [baseSymbol, quoteSymbol, counts, chain]
+    [baseSymbol, quoteSymbol, chain]
   );
 
   const sorted = useMemo(() => {

--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -10,6 +10,17 @@ export const CHAIN_TO_GT_NETWORK = {
   // add more as needed
 } as const;
 
+export const CHAIN_TO_ICON: Record<string, string> = {
+  ethereum: 'https://icons.llamao.fi/icons/chains/rsz_ethereum.jpg',
+  arbitrum: 'https://icons.llamao.fi/icons/chains/rsz_arbitrum.jpg',
+  base: 'https://icons.llamao.fi/icons/chains/rsz_base.jpg',
+  bsc: 'https://icons.llamao.fi/icons/chains/rsz_bsc.jpg',
+  polygon: 'https://icons.llamao.fi/icons/chains/rsz_polygon.jpg',
+  avalanche: 'https://icons.llamao.fi/icons/chains/rsz_avalanche.jpg',
+  optimism: 'https://icons.llamao.fi/icons/chains/rsz_optimism.jpg',
+  fantom: 'https://icons.llamao.fi/icons/chains/rsz_fantom.jpg',
+};
+
 export type GTNetwork = typeof CHAIN_TO_GT_NETWORK[keyof typeof CHAIN_TO_GT_NETWORK];
 
 export const SUPPORTED_GT_NETWORKS = new Set<GTNetwork>(

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -1,22 +1,22 @@
 import type { ChainSlug, Address, TxHash } from './types';
 
-const BASES: Record<string, string> = {
+const BASES = {
   ethereum: 'https://etherscan.io',
-  bsc: 'https://bscscan.com',
   base: 'https://basescan.org',
   arbitrum: 'https://arbiscan.io',
+  bsc: 'https://bscscan.com',
   polygon: 'https://polygonscan.com',
   optimism: 'https://optimistic.etherscan.io',
   avalanche: 'https://snowtrace.io',
-};
+} as const;
 
 export function addressUrl(chain: ChainSlug, addr: Address) {
-  const base = BASES[chain];
+  const base = (BASES as Record<string, string>)[chain];
   return base ? `${base}/address/${addr}` : undefined;
 }
 
 export function txUrl(chain: ChainSlug, hash: TxHash) {
-  const base = BASES[chain];
+  const base = (BASES as Record<string, string>)[chain];
   return base ? `${base}/tx/${hash}` : undefined;
 }
 

--- a/src/lib/format.tsx
+++ b/src/lib/format.tsx
@@ -12,12 +12,13 @@ export function formatCompact(value?: number): string {
 
 export function formatUsd(
   value?: number,
-  opts?: { compact?: boolean }
+  opts?: { compact?: boolean; dp?: number }
 ): string {
   if (value === undefined || value === null || !Number.isFinite(value)) return '-';
+  const dp = opts?.dp ?? 4;
   if (Math.abs(value) >= 1000 && opts?.compact !== false)
     return `$${formatCompact(value)}`;
-  return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(dp)}`;
 }
 
 export function formatDateTimeUTC(ts?: number): string {
@@ -60,6 +61,7 @@ export function subscriptZeros(frac: string): ReactNode[] {
 
 export function formatAmount(value?: number): ReactNode {
   if (value === undefined || value === null || !Number.isFinite(value)) return '-';
+  if (value === 0) return '0';
   const abs = Math.abs(value);
   if (abs >= 1) return value.toFixed(2);
 

--- a/src/lib/pairs.ts
+++ b/src/lib/pairs.ts
@@ -1,0 +1,10 @@
+import type { PoolSummary } from './types';
+
+export function resolvePairSymbols(
+  tokenSymbol: string,
+  pool: PoolSummary
+): { baseSymbol: string; quoteSymbol: string } {
+  return tokenSymbol === pool.base
+    ? { baseSymbol: pool.base, quoteSymbol: pool.quote }
+    : { baseSymbol: pool.quote, quoteSymbol: pool.base };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -184,16 +184,3 @@ tbody tr:nth-child(even) {
   color: inherit;
 }
 
-.copy-btn .tooltip {
-  position: absolute;
-  top: -1.5rem;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--bg-elev);
-  color: var(--text);
-  padding: var(--space-1) var(--space-2);
-  border-radius: var(--radius);
-  font-size: 0.75rem;
-  pointer-events: none;
-  white-space: nowrap;
-}

--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -9,7 +9,7 @@
   border: 2px solid var(--bg);
 }
 .chain-icons img + img {
-  margin-left: -8px;
+  margin-left: -6px;
 }
 .chain-more {
   margin-left: var(--space-1);

--- a/src/styles/tooltips.css
+++ b/src/styles/tooltips.css
@@ -1,0 +1,13 @@
+.tooltip {
+  position: absolute;
+  top: -1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-elev);
+  color: var(--text);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  pointer-events: none;
+  white-space: nowrap;
+}

--- a/src/styles/trades.css
+++ b/src/styles/trades.css
@@ -29,7 +29,7 @@
 .trades-header,
 .tr-row {
   display: grid;
-  grid-template-columns: 170px 60px 110px 110px 120px 120px 120px 40px 60px;
+  grid-template-columns: 170px 60px 110px 110px 120px 120px 180px 40px;
   align-items: center;
 }
 
@@ -83,11 +83,11 @@
   text-decoration: underline;
 }
 
-.tr-pill {
-  background: var(--border);
-  border-radius: var(--radius);
-  padding: 0 var(--space-2);
-  font-size: 0.75rem;
+
+.tr-cell.maker {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
 }
 
 .tr-row.buy .tr-cell.type {


### PR DESCRIPTION
## Summary
- show chain icons with overflow counter and tooltip in search results
- improve explorer helpers and accessible copy button with tooltip
- refine trades table formatting and resolve pair symbols

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a05737d300832389e4cb3537d68e69